### PR TITLE
fix: install native host for Arc and other Chromium browsers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,28 +27,67 @@ if ! command -v node &> /dev/null; then
 fi
 echo -e "${GREEN}✓${NC} Node.js found: $(node --version)"
 
-# Detect OS
+# Detect OS and collect all Chromium browser NativeMessagingHosts directories
+MANIFEST_DIRS=()
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    MANIFEST_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
     OS_NAME="macOS"
+    # Check all known Chromium-based browsers on macOS
+    CANDIDATE_DIRS=(
+        "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+        "$HOME/Library/Application Support/Arc/User Data/NativeMessagingHosts"
+        "$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
+        "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+        "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts"
+        "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts"
+    )
+    for dir in "${CANDIDATE_DIRS[@]}"; do
+        # Install if the parent directory exists (browser is installed)
+        parent_dir="$(dirname "$dir")"
+        if [[ -d "$parent_dir" ]]; then
+            MANIFEST_DIRS+=("$dir")
+        fi
+    done
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    MANIFEST_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
     OS_NAME="Linux"
+    CANDIDATE_DIRS=(
+        "$HOME/.config/google-chrome/NativeMessagingHosts"
+        "$HOME/.config/chromium/NativeMessagingHosts"
+        "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+        "$HOME/.config/microsoft-edge/NativeMessagingHosts"
+        "$HOME/.config/vivaldi/NativeMessagingHosts"
+    )
+    for dir in "${CANDIDATE_DIRS[@]}"; do
+        parent_dir="$(dirname "$dir")"
+        if [[ -d "$parent_dir" ]]; then
+            MANIFEST_DIRS+=("$dir")
+        fi
+    done
 else
     echo -e "${RED}✗ Unsupported OS: $OSTYPE${NC}"
     exit 1
 fi
+
+if [[ ${#MANIFEST_DIRS[@]} -eq 0 ]]; then
+    echo -e "${YELLOW}⚠${NC}  No Chromium-based browsers detected, installing for Chrome anyway"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        MANIFEST_DIRS=("$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts")
+    else
+        MANIFEST_DIRS=("$HOME/.config/google-chrome/NativeMessagingHosts")
+    fi
+fi
+
 echo -e "${GREEN}✓${NC} Detected OS: $OS_NAME"
+echo -e "${GREEN}✓${NC} Found ${#MANIFEST_DIRS[@]} browser(s) to configure"
 
 # Create install directory
 mkdir -p "$INSTALL_DIR"
 echo -e "${GREEN}✓${NC} Created $INSTALL_DIR"
 
-# Download oauth-server.cjs
+# Download native-bridge.cjs
 echo "Downloading native host..."
-curl -fsSL "$REPO_URL/native-host/oauth-server.cjs" -o "$INSTALL_DIR/oauth-server.cjs"
-chmod +x "$INSTALL_DIR/oauth-server.cjs"
-echo -e "${GREEN}✓${NC} Downloaded oauth-server.cjs"
+curl -fsSL "$REPO_URL/native-host/native-bridge.cjs" -o "$INSTALL_DIR/native-bridge.cjs"
+chmod +x "$INSTALL_DIR/native-bridge.cjs"
+echo -e "${GREEN}✓${NC} Downloaded native-bridge.cjs"
 
 # Get the full path to node (Chrome doesn't use shell, so we need explicit path)
 NODE_PATH=$(which node)
@@ -58,7 +97,7 @@ echo -e "${GREEN}✓${NC} Node path: $NODE_PATH"
 WRAPPER_SCRIPT="$INSTALL_DIR/native-host-wrapper.sh"
 cat > "$WRAPPER_SCRIPT" << EOF
 #!/bin/bash
-exec "$NODE_PATH" "$INSTALL_DIR/oauth-server.cjs" "\$@"
+exec "$NODE_PATH" "$INSTALL_DIR/native-bridge.cjs" "\$@"
 EOF
 chmod +x "$WRAPPER_SCRIPT"
 echo -e "${GREEN}✓${NC} Created wrapper script"
@@ -67,32 +106,30 @@ echo -e "${GREEN}✓${NC} Created wrapper script"
 CHROME_STORE_ID="iklpkemlmbhemkiojndpbhoakgikpmcd"  # Production (Chrome Web Store)
 DEV_ID="dnajlkacmnpfmilkeialficajdgkkkfo"          # Development (replace with your own if different)
 
-# Create manifest directory
-mkdir -p "$MANIFEST_DIR"
-
-# Create manifest pointing to wrapper script (not .cjs directly)
-MANIFEST_FILE="$MANIFEST_DIR/com.hanzi_in_chrome.oauth_host.json"
-cat > "$MANIFEST_FILE" << EOF
-{
-  "name": "com.hanzi_in_chrome.oauth_host",
-  "description": "OAuth local server for Hanzi in Chrome extension",
-  "path": "$WRAPPER_SCRIPT",
-  "type": "stdio",
-  "allowed_origins": [
-    "chrome-extension://$CHROME_STORE_ID/",
-    "chrome-extension://$DEV_ID/"
+# Install manifest to all detected browsers
+MANIFEST_CONTENT="{
+  \"name\": \"com.hanzi_in_chrome.oauth_host\",
+  \"description\": \"OAuth local server for Hanzi in Chrome extension\",
+  \"path\": \"$WRAPPER_SCRIPT\",
+  \"type\": \"stdio\",
+  \"allowed_origins\": [
+    \"chrome-extension://$CHROME_STORE_ID/\",
+    \"chrome-extension://$DEV_ID/\"
   ]
-}
-EOF
+}"
 
-echo -e "${GREEN}✓${NC} Configured for both production and development extensions"
-
-echo -e "${GREEN}✓${NC} Created manifest at: $MANIFEST_FILE"
+for MANIFEST_DIR in "${MANIFEST_DIRS[@]}"; do
+    mkdir -p "$MANIFEST_DIR"
+    MANIFEST_FILE="$MANIFEST_DIR/com.hanzi_in_chrome.oauth_host.json"
+    echo "$MANIFEST_CONTENT" > "$MANIFEST_FILE"
+    BROWSER_NAME="$(basename "$(dirname "$MANIFEST_DIR")")"
+    echo -e "${GREEN}✓${NC} Installed manifest for $BROWSER_NAME"
+done
 
 # Test
 echo ""
 echo "Testing native host..."
-if node "$INSTALL_DIR/oauth-server.cjs" <<< '{"type":"ping"}' 2>/dev/null | grep -q "pong"; then
+if node "$INSTALL_DIR/native-bridge.cjs" <<< '{"type":"ping"}' 2>/dev/null | grep -q "pong"; then
     echo -e "${GREEN}✓${NC} Native host test passed"
 else
     echo -e "${YELLOW}⚠${NC}  Test inconclusive (may still work)"
@@ -109,5 +146,8 @@ echo "  2. Open extension settings → Connect Claude Code or Codex"
 echo ""
 echo "To uninstall:"
 echo "  rm -rf $INSTALL_DIR"
-echo "  rm \"$MANIFEST_FILE\""
+echo "  # Remove manifests from all browsers:"
+for MANIFEST_DIR in "${MANIFEST_DIRS[@]}"; do
+    echo "  rm \"$MANIFEST_DIR/com.hanzi_in_chrome.oauth_host.json\""
+done
 echo ""


### PR DESCRIPTION
## Summary

- **install.sh only installed the native messaging host manifest to Chrome's directory**, so Arc, Brave, Edge, Vivaldi, and Chromium users got `Specified native messaging host not found` errors
- **Download URL referenced `oauth-server.cjs`** but the actual file in the repo is `native-bridge.cjs`, causing a 404 on fresh installs via `curl`

## Changes

- Auto-detect all installed Chromium-based browsers (Chrome, Arc, Chromium, Brave, Edge, Vivaldi) on both macOS and Linux
- Install the native messaging host manifest to each detected browser's `NativeMessagingHosts` directory
- Fix download filename from `oauth-server.cjs` to `native-bridge.cjs`
- Update wrapper script and test command to use correct filename
- Graceful fallback: if no browsers detected, install for Chrome anyway

## Test plan

- [ ] Run `install.sh` on macOS with Arc installed — verify manifest appears in `~/Library/Application Support/Arc/User Data/NativeMessagingHosts/`
- [ ] Run `install.sh` on macOS with Chrome only — verify it still works as before
- [ ] Verify the download URL no longer 404s
- [ ] Toggle extension off/on in Arc — confirm no "native host not found" error