### PR TITLE
Add Chinese README and setup guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ docs/*
 !docs/logo.svg
 !docs/diagrams/
 !docs/diagrams/*.svg
+!docs/zh/
+!docs/zh/*.md
 profiles/
 src/popup/
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,0 +1,234 @@
+<div align="center">
+
+<img src="../logo.svg" width="80" alt="Hanzi Browse" />
+
+# Hanzi Browse
+
+**给你的 AI agent 一个真实浏览器。**
+
+一次工具调用，就能把整段任务交给 agent 去完成。它会在你已经登录过的真实浏览器里点击、输入、填写表单，<br/>
+读取需要登录才能访问的页面，而不是在一个和你账号状态脱节的沙盒里“脑补”。
+
+[![npm](https://img.shields.io/npm/v/hanzi-browse?color=%23cb3837&label=npm)](https://www.npmjs.com/package/hanzi-browse)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/iklpkemlmbhemkiojndpbhoakgikpmcd?label=chrome%20web%20store&color=%234285F4)](https://chrome.google.com/webstore/detail/iklpkemlmbhemkiojndpbhoakgikpmcd)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/hahgu5hcA5)
+[![License](https://img.shields.io/badge/license-PolyForm%20NC-green)](../../LICENSE)
+
+**适配**
+
+<a href="https://claude.ai/code"><img src="https://browse.hanzilla.co/logos/claude-logo-0p9b6824.png" width="28" height="28" alt="Claude Code" title="Claude Code"></a>&nbsp;&nbsp;
+<a href="https://cursor.com"><img src="https://browse.hanzilla.co/logos/cursor-logo-5jxhjn17.png" width="28" height="28" alt="Cursor" title="Cursor"></a>&nbsp;&nbsp;
+<a href="https://openai.com/codex"><img src="https://browse.hanzilla.co/logos/openai-logo-6323x4zd.png" width="24" height="24" alt="Codex" title="Codex"></a>&nbsp;&nbsp;
+<a href="https://ai.google.dev/gemini-api/docs/cls"><img src="https://browse.hanzilla.co/logos/gemini-logo-1f6kvbwc.png" width="24" height="24" alt="Gemini CLI" title="Gemini CLI"></a>&nbsp;&nbsp;
+<img src="https://browse.hanzilla.co/logos/github-logo-tr9d8349.png" width="24" height="24" alt="VS Code" title="VS Code">&nbsp;&nbsp;
+<img src="https://browse.hanzilla.co/logos/kiro-logo-wk3s9bcy.png" width="24" height="24" alt="Kiro" title="Kiro">&nbsp;&nbsp;
+<img src="https://browse.hanzilla.co/logos/antigravity-logo-szj1gjgv.png" width="24" height="24" alt="Antigravity" title="Antigravity">&nbsp;&nbsp;
+<img src="https://browse.hanzilla.co/logos/opencode-logo-svpy0wcb.png" width="24" height="24" alt="OpenCode" title="OpenCode">
+
+<br/>
+
+[![Watch demo](https://img.youtube.com/vi/3tHzg2ps-9w/maxresdefault.jpg)](https://www.youtube.com/watch?v=3tHzg2ps-9w)
+
+</div>
+
+<br/>
+
+## 使用 Hanzi 的两种方式
+
+### 现在就用：给你的 agent 一个浏览器
+
+![Use it now](../diagrams/use-it.svg)
+
+### 集成到产品里：把浏览器自动化嵌进你的应用
+
+![Build with it](../diagrams/build-with-it.svg)
+
+<br/>
+
+## 快速开始
+
+```bash
+npx hanzi-browse setup
+```
+
+这一个命令会把主要步骤都串起来：
+
+```text
+npx hanzi-browse setup
+│
+├── 1. 检测浏览器 ───── Chrome、Brave、Edge、Arc、Chromium
+│
+├── 2. 安装扩展 ────── 打开 Chrome Web Store，并等待安装完成
+│
+├── 3. 检测 AI agent ─ Claude Code、Cursor、Codex、Windsurf、
+│                      VS Code、Gemini CLI、Amp、Cline、Roo Code
+│
+├── 4. 配置 MCP ───── 将 hanzi-browse 合并进各 agent 的配置
+│
+├── 5. 安装技能 ───── 把浏览器相关技能复制到各 agent
+│
+└── 6. 选择 AI 模式 ── Managed（$0.05/任务）或 BYOM（永久免费）
+```
+
+- **Managed**：官方托管模型与任务执行。每月 20 个免费任务，之后按 $0.05/任务计费，不需要 API Key。
+- **BYOM**：Bring Your Own Model。你可以使用 Claude Pro/Max、GPT Plus 或自己的 API Key。永久免费，本地运行。
+
+如果你在中国区网络环境、Windows PowerShell，或者 Chrome Web Store 不稳定，建议再看这份更实操的说明：
+
+- [中文安装指南](./setup-guide.md)
+
+<br/>
+
+## 示例
+
+```text
+"打开 Gmail，帮我退订最近一周的营销邮件"
+"去 careers.acme.com 帮我投递 senior engineer 岗位"
+"登录我的银行账户，把上个月账单下载下来"
+"去 LinkedIn 帮我找旧金山的 AI 工程师岗位"
+```
+
+<br/>
+
+## Skills
+
+安装向导会自动把浏览器技能装进你的 agent。技能的作用，是教 agent 在什么场景下该用浏览器，以及该怎么用浏览器完成特定流程。
+
+| Skill | 说明 |
+|-------|------|
+| `hanzi-browse` | 核心技能，定义何时以及如何使用浏览器自动化 |
+| `e2e-tester` | 在真实浏览器里测试你的应用，并带截图反馈问题 |
+| `social-poster` | 按不同平台改写文案，并用你已登录的账号发布 |
+| `linkedin-prospector` | 寻找潜在客户或候选人，并发送个性化连接请求 |
+| `a11y-auditor` | 在真实浏览器里执行无障碍检查 |
+| `x-marketer` | 面向 Twitter / X 的营销工作流 |
+
+开源可扩展，你也可以[自己写技能](https://github.com/hanzili/hanzi-browse/tree/main/server/skills)。
+
+<br/>
+
+## 基于 Hanzi Browse 构建产品
+
+把浏览器自动化嵌进自己的产品里。你的应用调用 Hanzi API，真实浏览器执行任务，然后把结果返回给你。
+
+1. **获取 API Key**：登录[开发者后台](https://api.hanzilla.co/dashboard)并创建 key
+2. **配对浏览器**：创建 pairing token，把配对链接（`/pair/{token}`）发给用户，用户点击后会自动配对
+3. **发起任务**：向 `POST /v1/tasks` 发送任务内容和浏览器 session ID
+4. **获取结果**：轮询 `GET /v1/tasks/:id` 直到完成，或者直接使用会阻塞等待的 `runTask()`
+
+```typescript
+import { HanziClient } from '@hanzi/browser-agent';
+
+const client = new HanziClient({ apiKey: process.env.HANZI_API_KEY });
+
+const { pairingToken } = await client.createPairingToken();
+const sessions = await client.listSessions();
+
+const result = await client.runTask({
+  browserSessionId: sessions[0].id,
+  task: 'Read the patient chart on the current page',
+});
+console.log(result.answer);
+```
+
+[API 文档](https://browse.hanzilla.co/docs.html#build-with-hanzi) · [开发者后台](https://api.hanzilla.co/dashboard) · [示例集成](../../examples/partner-quickstart/)
+
+<br/>
+
+## 工具
+
+| Tool | 说明 |
+|------|------|
+| `browser_start` | 发起一个任务，并阻塞等待直到任务完成 |
+| `browser_message` | 向现有会话发送后续指令 |
+| `browser_status` | 查询任务进度 |
+| `browser_stop` | 停止任务 |
+| `browser_screenshot` | 把当前页面截成 PNG |
+
+<br/>
+
+## 定价
+
+| | Managed | BYOM |
+|--|---------|------|
+| **价格** | $0.05/任务（每月前 20 个免费） | 永久免费 |
+| **AI 模型** | 官方托管（Gemini） | 使用你自己的 key |
+| **数据去向** | 任务数据会经过 Hanzi 服务器 | 数据不会离开你的机器 |
+| **计费方式** | 只对成功完成的任务收费，报错不收费 | 不适用 |
+
+如果你要把它集成到产品里，想谈量价，可以直接[联系作者](mailto:hanzili0217@gmail.com?subject=Partner%20pricing)。
+
+<br/>
+
+## 开发
+
+**前置条件：** [Node.js 18+](https://nodejs.org/) 和 [Docker Desktop](https://docs.docker.com/get-docker/)（必须已经启动）。
+
+### 第一次运行
+
+```bash
+git clone https://github.com/hanzili/hanzi-browse
+cd hanzi-browse
+make fresh
+```
+
+这个命令会检查环境、从模板生成 `.env`、安装依赖、完成构建、启动 Postgres、执行数据库迁移，并拉起本地开发服务。整个过程大约 90 秒。
+
+### 之后每次启动
+
+```bash
+make dev
+```
+
+它会启动 Postgres、执行迁移，并拉起开发服务。Dashboard 地址是 [localhost:3456/dashboard](http://localhost:3456/dashboard)。
+
+### 常用命令
+
+| Command | 说明 |
+|---------|------|
+| `make fresh` | 首次完整初始化（检查依赖 + 安装 + 构建 + 数据库 + 启动） |
+| `make dev` | 启动全部开发服务（数据库 + 迁移 + server） |
+| `make build` | 重新构建 server、dashboard 和 extension |
+| `make stop` | 停止 Postgres |
+| `make clean` | 停止并删除数据库卷 |
+| `make check-prereqs` | 检查 Node 18+ 和 Docker 是否可用 |
+| `make help` | 查看全部命令 |
+
+### 配置
+
+`.env.example` 的默认值足够把本地服务跑起来。下面这些服务是可选的：
+
+- **Google OAuth**（dashboard 登录）—— 在 `.env` 里补充 `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`
+- **Stripe**（购买积分流程）—— 在 `.env` 里补充测试环境 key
+- **Vertex AI**（托管模式任务执行）—— 具体步骤见 `.env.example`
+
+### 手动加载扩展
+
+打开 `chrome://extensions`，开启 Developer Mode，点击 “Load unpacked”，选择仓库根目录下的 `dist/` 文件夹。
+
+<br/>
+
+## 参与贡献
+
+欢迎提交贡献，具体说明见 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+很适合作为第一次贡献的方向包括：新技能、落地页、站点规则文件、平台兼容性测试，以及文档翻译。
+
+<br/>
+
+## 社区
+
+[Discord](https://discord.gg/hahgu5hcA5) · [在线文档](https://browse.hanzilla.co/docs.html) · [Twitter / X](https://x.com/user)
+
+<br/>
+
+## 隐私
+
+Hanzi 在不同模式下会采用不同的数据处理方式。完整说明请看[隐私政策](../../PRIVACY.md)。
+
+- **BYOM**：数据不会发送到 Hanzi 服务器，截图只会发给你选择的模型提供方
+- **Managed / API**：任务数据会通过 Google Vertex AI 在 Hanzi 服务器端处理
+
+## License
+
+[Polyform Noncommercial 1.0.0](../../LICENSE)

--- a/docs/zh/setup-guide.md
+++ b/docs/zh/setup-guide.md
@@ -1,0 +1,322 @@
+# Hanzi Browse 中文安装指南
+
+这份文档不是逐句翻译 README，而是按国内开发者常见的使用场景来写：
+
+- 只想先把扩展跑起来，看看值不值得折腾
+- 机器在中国区网络环境，`npm install`、Chrome Web Store、YouTube demo 访问不稳定
+- 用的是 Windows PowerShell，没有 `make`
+- 想本地起开发环境，但不想在第一步就被 Docker、Google OAuth、Vertex AI 这些东西劝退
+
+如果你想先看项目全貌，再回来照着装，可以先读：[中文版 README](./README.md)
+
+## 先说结论
+
+### 如果你只是想体验浏览器扩展
+
+你其实不需要先把整套后端都跑起来。最短路径是：
+
+1. 安装根目录依赖
+2. 构建扩展
+3. 在 `chrome://extensions` 手动加载 `dist/`
+
+这样就能先看到扩展本体，Chrome Web Store 打不开也不影响。
+
+### 如果你想跑完整本地开发环境
+
+README 里的标准流程是：
+
+```bash
+make fresh
+```
+
+但这条命令默认站在 macOS / Linux 的角度写的。在 Windows 上，你通常要手动拆成几步来跑。后面我会给你一份 PowerShell 版本。
+
+## 环境准备
+
+先确认这些东西都在：
+
+- Node.js 18 或更高
+- npm
+- Docker Desktop
+- 一个 Chromium 内核浏览器：Chrome、Edge、Brave 都行
+
+可选但很省事：
+
+- Git Bash 或 WSL，如果你想尽量原样照着 `make` 走
+
+## 中国区网络环境下最容易卡住的地方
+
+### 1. npm 安装慢
+
+默认先试官方源。如果你本机拉 npm 包一直超时，再切镜像。
+
+临时用镜像装依赖：
+
+```bash
+npm install --registry=https://registry.npmmirror.com
+```
+
+如果你想全局切过去：
+
+```bash
+npm config set registry https://registry.npmmirror.com
+```
+
+装完想切回官方源：
+
+```bash
+npm config set registry https://registry.npmjs.org
+```
+
+经验建议：
+
+- 网络本来就稳的话，别急着改全局 registry
+- 如果只是偶发超时，优先用单次命令参数，不要一上来全局改配置
+
+### 2. Chrome Web Store 打不开
+
+这个仓库本身就支持手动侧载扩展，所以别把 Chrome Web Store 当成硬前置。
+
+开发阶段推荐直接这样装：
+
+1. 跑出根目录的 `dist/`
+2. 打开 `chrome://extensions`
+3. 打开右上角 Developer Mode
+4. 点 “Load unpacked”
+5. 选择仓库根目录的 `dist/`
+
+只要 `dist/` 构建成功，扩展就能装。
+
+### 3. 某些上游服务访问不稳定
+
+下面这些能力依赖国外服务，国内网络下不一定顺：
+
+- Chrome Web Store
+- YouTube demo
+- Google OAuth
+- Stripe
+- Vertex AI
+- 你自己选的 AI provider（比如 OpenAI、Anthropic 等）
+
+这不代表 Hanzi Browse 不能用，而是说明你要分清自己现在在测哪一层：
+
+- **只测扩展 UI / 本地构建**：可以先不碰这些服务
+- **只测手动加载扩展**：不需要 Chrome Web Store
+- **要测 Managed 模式、OAuth、支付、Vertex AI**：就需要准备能稳定访问对应上游服务的网络环境
+
+## 路线 A：只把扩展跑起来
+
+这条路线最适合第一次上手。
+
+### 1. 拉代码
+
+```bash
+git clone https://github.com/hanzili/hanzi-browse
+cd hanzi-browse
+```
+
+### 2. 安装根目录依赖
+
+```bash
+npm install
+```
+
+如果慢，就带上镜像：
+
+```bash
+npm install --registry=https://registry.npmmirror.com
+```
+
+### 3. 构建扩展
+
+```bash
+npm run build
+```
+
+### 4. 手动加载扩展
+
+打开 `chrome://extensions`：
+
+1. 打开 Developer Mode
+2. 选择 “Load unpacked”
+3. 选择仓库根目录下的 `dist/`
+
+到这里，你已经能在浏览器里看到 Hanzi Browse 扩展了。
+
+## 路线 B：跑完整本地开发环境
+
+### macOS / Linux
+
+如果你就在 macOS 或 Linux，而且本机有 `make`，那就直接按原 README 走：
+
+```bash
+git clone https://github.com/hanzili/hanzi-browse
+cd hanzi-browse
+make fresh
+```
+
+后续日常开发用：
+
+```bash
+make dev
+```
+
+### Windows PowerShell
+
+Windows 上最常见的问题不是 Node，也不是 Docker，而是 README 默认你有 `make` 和类 Unix shell。PowerShell 用户可以直接按下面这套等价步骤来。
+
+### 1. 拉代码并进入目录
+
+```powershell
+git clone https://github.com/hanzili/hanzi-browse
+cd hanzi-browse
+```
+
+### 2. 复制环境变量模板
+
+```powershell
+Copy-Item .env.example .env
+```
+
+默认配置已经够你把本地服务跑起来。只有当你要测 Google 登录、Stripe、Vertex AI 时，才需要再补 `.env`。
+
+### 3. 安装三层依赖
+
+```powershell
+npm install
+cd server
+npm install
+cd dashboard
+npm install
+cd ..\..
+```
+
+### 4. 构建扩展
+
+```powershell
+npm run build
+```
+
+### 5. 构建 server 和 dashboard
+
+```powershell
+cd server
+npm run build
+cd ..
+```
+
+如果这一步遇到 TypeScript 报错，建议先区分是环境问题还是源码问题：
+
+- 先确认三层依赖都已经装完
+- 再看最新的 `main` 和已有 issue，确认是不是当前版本本身就存在未收敛的构建问题
+- 不要一上来就把问题归因到 npm 镜像或中国区网络环境
+
+### 6. 启动 Docker Desktop
+
+这一步别省。`docker --version` 有输出，不代表 Docker Engine 已经真的启动。
+
+确认方法：
+
+```powershell
+docker info
+```
+
+如果这条命令报错，先把 Docker Desktop 打开并等它完全启动。
+
+### 7. 起本地 Postgres
+
+```powershell
+docker compose up -d postgres
+```
+
+本地数据库会映射到 `localhost:5433`，避免和你机器上自己的 5432 冲突。
+
+### 8. 跑数据库 schema
+
+```powershell
+docker compose exec -T postgres psql -U hanzi -d hanzi -f /docker-entrypoint-initdb.d/schema.sql
+```
+
+### 9. 补上 Windows 下的目录链接
+
+README 里的 `make setup` 会创建两个链接目录，`server` 里启动 managed API 时会用到它们。
+
+在 PowerShell 里可以这样建目录联接：
+
+```powershell
+New-Item -ItemType Junction -Path server\landing -Target .\landing
+New-Item -ItemType Junction -Path server\sdk -Target .\sdk
+```
+
+如果目录已经存在，就跳过这步。
+
+### 10. 启动 managed API
+
+```powershell
+cd server
+node dist/managed/deploy.js
+```
+
+正常情况下可以访问：
+
+- <http://localhost:3456/dashboard>
+
+## Chrome 扩展侧载说明
+
+如果 Chrome Web Store 访问不了，或者你就是在本地开发，推荐一直用侧载，不必纠结商店安装。
+
+步骤再总结一遍：
+
+1. 构建出 `dist/`
+2. 打开 `chrome://extensions`
+3. 开启 Developer Mode
+4. Load unpacked
+5. 选 `dist/`
+
+每次你重新构建扩展之后，去扩展页点一下刷新就行。
+
+## 常见问题
+
+### `make` 找不到
+
+这在 Windows 上很正常，不是你装错了。
+
+解决思路有两个：
+
+- 用 Git Bash / WSL，尽量按 README 原样跑
+- 用这份文档里的 PowerShell 分步命令
+
+### `docker --version` 正常，但 `docker info` 报错
+
+说明 Docker CLI 装了，但 Docker Desktop 还没真正启动。
+
+### `npm run build` 能过，但 `cd server && npm run build` 失败
+
+先确认依赖安装完整；如果依赖没问题，再去看最新主分支和已有 issue，判断是不是当前版本本身的源码问题。
+
+### Chrome Web Store 打不开
+
+直接侧载 `dist/`，完全不影响本地开发。
+
+### 要不要准备“特殊网络环境”
+
+如果你只是想本地构建、手动加载扩展、看 UI，不一定需要。
+
+如果你要测试这些功能，就要确认你能稳定访问对应服务：
+
+- Managed 模式
+- Google OAuth
+- Stripe
+- Vertex AI
+- 你选的 LLM 提供商
+
+## 更像给朋友的建议
+
+第一次上手，建议别一口气把所有功能都跑通。更稳的顺序是：
+
+1. 先 `npm install`
+2. 先把 `npm run build` 跑通
+3. 先把扩展侧载到浏览器里
+4. 确认你真的需要 dashboard / managed API，再去折腾 Docker、数据库和 OAuth
+
+这样心态会好很多，也更容易判断问题到底出在仓库、环境，还是上游服务。


### PR DESCRIPTION
## Summary
- Add `docs/zh/README.md`, a Chinese README aligned with the English README's section order, diagrams, tables, and links, but rewritten in natural Chinese rather than literal translation.
- Add `docs/zh/setup-guide.md`, a China-focused setup guide covering npm registry speed, Chrome extension sideloading, Windows PowerShell alternatives to `make`, and network considerations for upstream services.
- Update `.gitignore` to allow `docs/zh/*.md` so the translated docs can be tracked in Git.

## Review
- The Chinese docs were reviewed by @JYins for language quality, clarity, and natural phrasing.

## Validation
- `npm install`
- `cd server && npm install`
- `cd server/dashboard && npm install`
- `npm run build`
- `cd server && npm run build` currently hits existing TypeScript errors in `server/src/managed/api.ts`; this appears to be a pre-existing repo issue rather than a result of this docs PR.