### PR TITLE
Partial implementation for #23: job-applier skill and initial site patterns

### DIFF
--- a/server/site-patterns/greenhouse.io.md
+++ b/server/site-patterns/greenhouse.io.md
@@ -1,0 +1,47 @@
+---
+domain: greenhouse.io
+aliases: [Greenhouse]
+updated: 2026-03-29
+---
+
+## Platform traits
+
+- Verified on a public board page at `https://job-boards.greenhouse.io/typeface/jobs/4827956007`.
+- The tested page is a JavaScript application, but it still exposes useful structured application metadata in the initial HTML payload.
+- The board used Greenhouse's job-board app assets from `job-boards.cdn.greenhouse.io` and exposed Remix route state in the page source.
+- The page exposed both the human-facing job page and the submit / confirmation paths without logging in.
+
+## Effective patterns
+
+- Start from the public posting URL, then inspect the in-page metadata before automating:
+  - tested posting URL: `https://job-boards.greenhouse.io/typeface/jobs/4827956007`
+  - embedded submit path: `https://boards.greenhouse.io/typeface/jobs/4827956007`
+  - embedded confirmation path: `/typeface/jobs/4827956007/confirmation`
+  - back-to-jobs pattern: `https://job-boards.greenhouse.io/{company}`
+- The tested page exposed an `Apply` button directly in HTML:
+  - selector observed in source: `button[aria-label="Apply"]`
+  - application container hook observed in source: `div.application--container`
+- Structured question metadata was embedded in page JSON. Verified fields included:
+  - `first_name`
+  - `last_name`
+  - `email`
+  - `phone`
+  - `resume`
+  - `resume_text`
+  - `cover_letter`
+  - `cover_letter_text`
+  - LinkedIn / website text inputs
+  - single-select sponsorship and work-authorization questions
+- Upload requirements were visible in the metadata before interacting:
+  - allowed file types for resume and cover letter: `pdf`, `doc`, `docx`, `txt`, `rtf`
+- The tested page also exposed `quickApply.active: true` and `quickApply.url: https://my.greenhouse.io`. Treat this as board-specific capability, not a universal guarantee.
+- Because the question schema is visible in-page, Greenhouse is well-suited for a two-step workflow:
+  1. inspect the posting and identify required fields without using the browser heavily
+  2. open the live form only after the user confirms they want to proceed
+
+## Known traps
+
+- The page is still a client-side app. Metadata is visible early, but actual interaction and submission should still be treated as browser work.
+- Quick Apply support appeared in the tested posting, but a user may not want to authenticate through Greenhouse. Confirm before using any quick-apply path.
+- Required questions differ by employer. Even when the top-level schema is visible, do not assume later steps are trivial or identical across boards.
+- If the page renders but the app shell fails to hydrate, fall back to the embedded metadata for planning, then retry in the browser instead of guessing missing fields.

--- a/server/site-patterns/lever.co.md
+++ b/server/site-patterns/lever.co.md
@@ -1,0 +1,39 @@
+---
+domain: lever.co
+aliases: [Lever]
+updated: 2026-03-29
+---
+
+## Platform traits
+
+- Verified on public posting and application pages under `https://jobs.lever.co/{company}/{posting-id}` and `https://jobs.lever.co/{company}/{posting-id}/apply`.
+- The application form is server-rendered HTML. Public pages expose meaningful structure without needing to execute the full app first.
+- Lever boards commonly expose the entire application form on the `/apply` URL, including upload fields, custom questions, and the final submit button.
+- The tested application page included Cloudflare-managed assets and an hCaptcha widget, so public access does not guarantee friction-free submission.
+
+## Effective patterns
+
+- Use the listing URL first, then append `/apply` when you are ready to inspect or fill the form:
+  - Listing example: `https://jobs.lever.co/applydigital/b8990278-260e-495b-9eaa-f6f39eae9eff`
+  - Apply example: `https://jobs.lever.co/applydigital/b8990278-260e-495b-9eaa-f6f39eae9eff/apply`
+- The tested `/apply` page exposed these stable hooks directly in HTML:
+  - submit button: `button#btn-submit[data-qa="btn-submit"]`
+  - additional info field: `textarea[name="comments"]`
+  - hCaptcha container: `div#h-captcha.h-captcha`
+  - hidden LinkedIn payload field: `input[name="linkedInData"]`
+- Resume upload guidance was visible before interacting:
+  - label text: `Attach resume/CV`
+  - allowed types shown on page: `pdf, doc, docx, txt, rtf`
+  - size note shown on page: `100MB max`
+- Custom questions were embedded in the HTML in `cards[...]` sections, with field types visible from source. Verified examples included:
+  - free-text textarea for project / portfolio details
+  - radio-button questions for timezone overlap, work authorization, English proficiency, and background-check consent
+  - text inputs for notice period and compensation
+- Because the form is visible in source, Lever is a good candidate for preflight inspection before opening a full browser automation session. You can often learn whether a cover letter, compensation answer, or work authorization response will be required before filling anything.
+
+## Known traps
+
+- hCaptcha is present on the tested apply page. If it blocks submission, stop and ask the user to solve it manually rather than retrying automatically.
+- Lever custom questions vary a lot by company. Do not assume the same required fields across postings, even within the same board.
+- The page included LinkedIn apply hooks, but that does not mean a LinkedIn autofill path is reliable or available for every posting. Treat it as optional enhancement, not the primary plan.
+- Cloudflare challenge scripts were present in the tested page. If the browser lands on a challenge screen or gets rate-limited, pause and let the user intervene.

--- a/server/site-patterns/workday.com.md
+++ b/server/site-patterns/workday.com.md
@@ -1,0 +1,48 @@
+---
+domain: workday.com
+aliases: [Workday]
+updated: 2026-03-29
+---
+
+## Platform traits
+
+- Verified on General Motors' public board hosted at `generalmotors.wd5.myworkdayjobs.com`.
+- The tested board uses Workday's `cxs` app pattern. Listing discovery works through a public JSON endpoint, while individual posting pages are mostly a dynamic app shell.
+- Public posting pages can still expose useful runtime configuration in the HTML, including locale, posting availability, and file-type restrictions.
+- Workday behavior is tenant-specific. The patterns below were confirmed on the GM tenant and should be re-validated when switching to another employer's Workday board.
+
+## Effective patterns
+
+- For listing discovery, the verified public endpoint was:
+  - `POST https://generalmotors.wd5.myworkdayjobs.com/wday/cxs/generalmotors/Careers_GM/jobs`
+  - sending `{}` returned JSON with `total`, `jobPostings`, and `facets`
+- Useful fields from the listing response included:
+  - `title`
+  - `externalPath`
+  - `locationsText`
+  - `postedOn`
+  - `remoteType`
+  - `bulletFields`
+- Use `externalPath` from that JSON to build or verify the public job URL before opening the browser.
+- A live posting verified during testing:
+  - `https://generalmotors.wd5.myworkdayjobs.com/Careers_GM/job/Remote---United-States/Senior-Data-Engineer_JR-202605861-1`
+- The same posting also exposed a canonical URL in HTML using the locale-aware pattern:
+  - `https://generalmotors.wd5.myworkdayjobs.com/en-US/Careers_GM/job/Remote---United-States/Senior-Data-Engineer_JR-202605861-1`
+- The tested posting page was mostly an SPA shell with `div#root`, but the HTML still exposed runtime values that are useful before automation:
+  - `postingAvailable: true`
+  - `tenant: "generalmotors"`
+  - `siteId: "Careers_GM"`
+  - `requestLocale: "en-US"`
+  - `supportedLocales: ["en-US", "en-CA", "en-GB", "es", "fr-CA", "fr-FR", "pt-BR", "th-TH", "ko-KR"]`
+  - `blockedFileTypes: ["bas", "bat", "com", "exe", "js", "lnk", "ocx", "reg", "sct", "sys", "vb", "vbe", "vbs", "wsc", "wsf", "wsh"]`
+- Practical workflow for Workday-backed boards:
+  1. use the JSON jobs endpoint to search and collect listings without the browser
+  2. verify the posting is still open with the public page and `postingAvailable`
+  3. use browser automation only after the user picks a role
+
+## Known traps
+
+- The public posting page is not enough to reveal the full interactive application form. Expect to need a real browser session once you begin the application.
+- Workday tenants differ. A pattern confirmed on `generalmotors.wd5.myworkdayjobs.com` should be treated as proven for that tenant, not automatically for every Workday employer.
+- Some stale posting URLs still return a page shell but expose `postingAvailable: false`. Check that before investing time in automation.
+- Upload restrictions may be partially visible from runtime config, but the absence of explicit allowed types in the tested page means you should still validate uploads in the live flow instead of assuming anything beyond the blocked extensions list.

--- a/server/skills/job-applier/SKILL.md
+++ b/server/skills/job-applier/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: job-applier
+description: Find job listings, let the user choose which ones to pursue, and apply from the user's real signed-in browser with explicit approval before every final submission. Supports reusable patterns for Lever, Greenhouse, and Workday-backed boards.
+---
+
+# Job Applier
+
+You help the user find jobs, shortlist the right ones, and complete applications from the user's real browser one at a time.
+
+## Tool Selection Rule
+
+- **Prefer non-browser tools first**: use search, APIs, public job-board pages, local files, and MCP integrations to collect listings before opening any application flow.
+- **Use Hanzi only for browser-required steps**: signed-in flows, resume uploads, answering application questions, and final submission.
+- **Every application is consequential**: show the user what you found, warn about duplicates, and get explicit approval before every final submit click.
+
+## Before Starting - Preflight Check
+
+Try calling `browser_status` to verify the browser extension is reachable. If the tool doesn't exist or returns an error:
+
+> **Hanzi isn't set up yet.** This skill needs the hanzi browser extension running in Chrome.
+>
+> 1. Install from the Chrome Web Store: https://chromewebstore.google.com/detail/hanzi-browse/iklpkemlmbhemkiojndpbhoakgikpmcd
+> 2. The extension will walk you through setup (~1 minute)
+> 3. Then come back and run this again
+
+---
+
+## What You Need From the User
+
+1. **Target roles** - job titles, seniority, and preferred industries
+2. **Location preferences** - remote, hybrid, on-site, and geography constraints
+3. **Resume highlights** - strongest experience, projects, technologies, measurable wins
+4. **Work authorization** - visa status, sponsorship needs, and country-specific eligibility
+5. **Compensation constraints** - if the user wants to filter on salary or avoid low-range roles
+6. **Cover letter preference** - no cover letter, brief and direct, or more tailored and persuasive
+7. **Common screening answers** - notice period, years of experience, portfolio links, LinkedIn, GitHub, relocation preference, security clearance, and similar recurring questions
+8. **Skip rules** - whether to skip applications that require creating an account, writing a custom essay, or re-entering a full work history manually
+
+If any of these are missing, ask before opening submission flows.
+
+---
+
+## Supported Platform Knowledge
+
+When the target posting is on one of these platforms, use the matching site-pattern file before touching the browser:
+
+- `server/site-patterns/lever.co.md`
+- `server/site-patterns/greenhouse.io.md`
+- `server/site-patterns/workday.com.md`
+
+If the site does not match one of those files, continue carefully and record any new patterns you verify.
+
+---
+
+## Phase 1: Search and Collect Listings (no browser if possible)
+
+Start with public search and listing collection before opening applications.
+
+1. Search for roles using public job board pages, company career pages, or known API-backed listings.
+2. Collect the essentials for each listing:
+   - company
+   - title
+   - location / remote status
+   - platform
+   - job URL
+   - any obvious blockers such as sponsorship mismatch or account-only flow
+3. Prefer lightweight discovery over browser automation:
+   - Lever: public job pages and `/apply` routes are directly readable
+   - Greenhouse: public job pages expose structured application metadata in-page
+   - Workday: public boards may expose listing data via `wday/cxs/.../jobs` endpoints, then require browser work for the actual application flow
+4. Do not start an application just to gather basic listing data unless the site hides the details behind the first step.
+
+If the user gave a fixed list of jobs, validate them and skip straight to Phase 2.
+
+---
+
+## Phase 2: Show the Shortlist Before Applying
+
+Present the collected jobs in a structured table before opening any application:
+
+| # | Company | Title | Location | Platform | Notable questions / blockers | Status |
+|---|---------|-------|----------|----------|-------------------------------|--------|
+
+Use the `Notable questions / blockers` column for things like:
+
+- sponsorship or work authorization questions
+- required cover letter
+- duplicate risk
+- likely account creation requirement
+- heavy custom questionnaire
+
+Ask the user which jobs to pursue. If the list is long, recommend an order and explain why.
+
+Do not begin submissions until the user confirms the shortlist.
+
+---
+
+## Phase 3: Apply One Job at a Time
+
+Use separate browser runs for each application. Never submit in parallel.
+
+For each selected job:
+
+1. Re-check the URL and platform.
+2. Check for duplicate risk before doing any work:
+   - ask whether the user remembers already applying
+   - check any existing local application log if available
+   - if the platform shows a prior application state, stop and confirm
+3. Open the application flow.
+4. Fill the form carefully using the user's approved materials:
+   - resume / CV upload
+   - contact details
+   - LinkedIn, portfolio, GitHub, website
+   - screening questions
+   - optional cover letter only if the user wants one
+5. Before the final submit action, show the user:
+   - company and title
+   - the current screen state
+   - any answers that may affect eligibility
+   - any missing or suspicious fields
+6. Ask for explicit approval before the final submit click.
+7. Submit only after approval.
+8. Record the result immediately: submitted, blocked, abandoned, duplicate, or failed.
+
+If `browser_start` times out, call `browser_screenshot` to see where it got stuck, then `browser_message` to continue or `browser_stop` to end the session.
+
+---
+
+## Phase 4: Report Results
+
+When the session ends, report each selected job clearly:
+
+| Company | Title | Platform | Outcome | Notes |
+|---------|-------|----------|---------|-------|
+
+Include:
+
+- submitted applications
+- duplicates skipped
+- blocked flows such as CAPTCHA, login walls, or broken uploads
+- applications abandoned because the user chose not to continue
+- anything that should be added back into the user's reusable answer bank for the next batch
+
+If you learned a reusable platform-specific behavior, note which site-pattern file should be updated next time.
+
+---
+
+## Safety Rules
+
+- Never click the final submit button without explicit user approval for that specific job
+- Never apply to multiple jobs in parallel
+- Warn about duplicate applications before filling or submitting
+- If the site shows CAPTCHA, fraud checks, rate-limit warnings, or unusual anti-bot friction, stop and tell the user
+- If the form asks for information the user has not approved, stop and ask
+- If the application requires account creation and the user said to skip those, stop and skip
+- If the application requires a custom essay or additional documents the user did not agree to provide, stop and ask
+- Do not invent answers to eligibility, compensation, security clearance, or legal-status questions
+
+---
+
+## Platform Notes
+
+### Lever
+
+- Public listing pages are readable without login and the `/apply` route usually exposes the application form directly.
+- Resume upload, contact info, and custom questions are often visible in the page source before interacting.
+- Expect explicit work authorization and compensation questions on many postings.
+
+### Greenhouse
+
+- Public job pages often expose structured question metadata in-page, which makes it possible to preview required fields before opening the full flow.
+- Some boards expose quick-apply options, but do not assume the user wants to use them.
+- Application flows can still require browser interaction for uploads and final submission.
+
+### Workday
+
+- Listing discovery may be easier through public JSON endpoints than through the browser UI.
+- The actual application flow is usually a dynamic app, so browser automation is often required once the user chooses a role.
+- Validate that the posting is still open before investing time in the form.
+
+---
+
+## When Done
+
+Summarize:
+
+- how listings were collected
+- how many jobs were reviewed
+- how many the user chose
+- submitted / skipped / blocked / failed counts
+- any repeated friction points across platforms
+- any reusable answers or documents the user should keep ready for the next run


### PR DESCRIPTION
## Summary

This is a partial implementation for #23.

It adds:
- `server/skills/job-applier/SKILL.md`
- `server/site-patterns/lever.co.md`
- `server/site-patterns/greenhouse.io.md`
- `server/site-patterns/workday.com.md`

The goal of this PR is to land the reusable text scaffolding first:
- a `job-applier` skill that follows the existing `SKILL.md` structure
- the first 3 verified job-platform site-pattern files needed to support it

## What This Covers

- The skill now explicitly:
  - prefers non-browser listing collection first
  - asks the user for resume highlights, work authorization, cover letter preference, and recurring screening answers
  - separates the workflow into search, shortlist, apply, and reporting phases
  - requires explicit approval before every final submission
  - warns about duplicates, CAPTCHA, login walls, and unsupported account-creation flows
- The included site-pattern files document real public-page findings for:
  - Lever
  - Greenhouse
  - Workday (verified on the GM tenant)

## What This PR Does Not Claim

This PR does **not** claim that issue #23 is fully complete yet.

I did not claim the "applied to 20+ real jobs using hanzi-browse" requirement, because this branch only contributes the reusable skill text plus verified platform notes gathered from real public job pages. The actual end-to-end application evidence still needs to be collected honestly in a follow-up pass.

## Validation

- Confirmed the new skill matches the structure used by existing skills such as `social-poster` and `linkedin-prospector`
- Wrote the platform notes from live public job pages / endpoints rather than guessed patterns
- `git diff --check` passes

## Follow-up

After this partial lands or gets feedback, I plan to:
- gather real application evidence for #23
- expand site patterns further as part of #15 (`indeed.com`, `linkedin.com/jobs`, `glassdoor.com`)