### PR TITLE
fix: align local managed relay onboarding handlers

### DIFF
--- a/server/src/managed/deploy.ts
+++ b/server/src/managed/deploy.ts
@@ -19,6 +19,7 @@ import { WebSocketServer, WebSocket } from "ws";
 import { createServer, IncomingMessage, ServerResponse } from "http";
 import { randomUUID } from "crypto";
 import { initVertex } from "../llm/vertex.js";
+import { getClaudeCredentials, getClaudeKeychainCredentials, getCodexCredentials } from "../llm/credentials.js";
 import { startManagedAPI, initManagedAPI, handleRelayMessage, setStoreModule, onSessionDisconnected, shutdownManagedAPI, recoverStuckTasks, runInternalTask } from "./api.js";
 import { initScheduler, startScheduler, stopScheduler } from "./scheduler.js";
 import { notifyDraftsReady } from "./notify.js";
@@ -248,6 +249,80 @@ function setupRelayHandlers(wss: WebSocketServer): void {
 
         const sender = relayClients.get(ws);
         if (!sender) return;
+
+        // Match standalone relay behavior for onboarding / credential import flows.
+        if (msg.type === "status_query") {
+          const ext = getLegacyExtension();
+          ws.send(JSON.stringify({
+            type: "status_response",
+            requestId: msg.requestId,
+            extensionConnected: !!ext && ext.ws.readyState === WebSocket.OPEN,
+          }));
+          return;
+        }
+
+        if (msg.type === "read_credentials" && sender.role === "extension") {
+          const { credentialType } = msg;
+
+          try {
+            if (credentialType === "claude") {
+              const creds = getClaudeCredentials() || getClaudeKeychainCredentials();
+              if (creds) {
+                ws.send(JSON.stringify({
+                  type: "credentials_result",
+                  requestId: msg.requestId,
+                  credentialType: "claude",
+                  credentials: {
+                    accessToken: creds.accessToken,
+                    refreshToken: creds.refreshToken,
+                    expiresAt: creds.expiresAt,
+                  },
+                }));
+              } else {
+                ws.send(JSON.stringify({
+                  type: "credentials_result",
+                  requestId: msg.requestId,
+                  credentialType: "claude",
+                  error: "Claude credentials not found. Run `claude login` first.",
+                }));
+              }
+            } else if (credentialType === "codex") {
+              const creds = getCodexCredentials();
+              if (creds) {
+                ws.send(JSON.stringify({
+                  type: "credentials_result",
+                  requestId: msg.requestId,
+                  credentialType: "codex",
+                  credentials: {
+                    accessToken: creds.accessToken,
+                    refreshToken: creds.refreshToken,
+                    accountId: creds.accountId,
+                  },
+                }));
+              } else {
+                ws.send(JSON.stringify({
+                  type: "credentials_result",
+                  requestId: msg.requestId,
+                  credentialType: "codex",
+                  error: "Codex credentials not found. Run `codex auth login` first.",
+                }));
+              }
+            } else {
+              ws.send(JSON.stringify({
+                type: "credentials_result",
+                requestId: msg.requestId,
+                error: `Unknown credential type: ${credentialType}`,
+              }));
+            }
+          } catch (err: any) {
+            ws.send(JSON.stringify({
+              type: "credentials_result",
+              requestId: msg.requestId,
+              error: err.message,
+            }));
+          }
+          return;
+        }
 
         // --- Managed routing: route by targetSessionId ---
         // SECURITY: Only the internal managed backend (authenticated with relay_secret)


### PR DESCRIPTION
## Summary
- add the missing onboarding relay handlers to `server/src/managed/deploy.ts`
- align local managed relay behavior with the standalone relay for `status_query` and `read_credentials`
- unblock local onboarding credential import for Claude Code and Codex

## Verification
- built the server with `npm run build` in `server/`
- started the local managed backend / relay and confirmed `http://127.0.0.1:3456` returns `200`
- verified over WebSocket that registering as `role: extension` now receives both `status_response` and `credentials_result`

Fixes #49.