### PR TITLE
test: add setup wizard unit coverage

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "cli": "node dist/cli.js",
-    "test": "npx tsx test/test-agents.ts",
+    "test": "vitest run",
     "test:live": "npx tsx test/test-live.ts",
     "test:followup": "npx tsx test/test-followup.ts"
   },

--- a/server/src/cli/setup.ts
+++ b/server/src/cli/setup.ts
@@ -39,6 +39,28 @@ interface SetupResult {
   detail: string;
 }
 
+interface AgentRegistryDeps {
+  home?: string;
+  plat?: NodeJS.Platform;
+  appData?: string;
+  pathExists?: (path: string) => boolean;
+  runCommand?: (command: string, options?: any) => Buffer | string;
+}
+
+interface JsonConfigDeps {
+  pathExists?: (path: string) => boolean;
+  readTextFile?: (path: string, encoding: BufferEncoding) => string;
+  writeTextFile?: (path: string, contents: string) => void;
+  ensureDir?: (path: string, options: { recursive: boolean }) => void;
+  copyFile?: (source: string, destination: string) => void;
+}
+
+interface BrowserDetectionDeps {
+  plat?: NodeJS.Platform;
+  pathExists?: (path: string) => boolean;
+  runCommand?: (command: string, options?: any) => Buffer | string;
+}
+
 // ── Style ──────────────────────────────────────────────────────────────
 
 const c = {
@@ -99,12 +121,15 @@ const MCP_ENTRY = {
 
 // ── Agent registry ─────────────────────────────────────────────────────
 
-function getAgentRegistry(): AgentConfig[] {
-  const home = homedir();
-  const plat = platform();
+export function getAgentRegistry(deps: AgentRegistryDeps = {}): AgentConfig[] {
+  const home = deps.home ?? homedir();
+  const plat = deps.plat ?? platform();
+  const appData = deps.appData ?? process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
+  const pathExists = deps.pathExists ?? existsSync;
+  const runCommand = deps.runCommand ?? execSync;
 
   const hasCli = (bin: string) => {
-    try { execSync(`which ${bin}`, { stdio: 'ignore' }); return true; } catch { return false; }
+    try { runCommand(`which ${bin}`, { stdio: 'ignore' }); return true; } catch { return false; }
   };
 
   return [
@@ -124,7 +149,7 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.cursor', 'mcp.json'),
       skillsDir: () => join(home, '.cursor', 'skills'),
-      detect: () => existsSync(join(home, '.cursor')),
+      detect: () => pathExists(join(home, '.cursor')),
     },
     {
       name: 'Windsurf',
@@ -132,7 +157,7 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.codeium', 'windsurf', 'mcp_config.json'),
       skillsDir: () => join(home, '.codeium', 'windsurf', 'skills'),
-      detect: () => existsSync(join(home, '.codeium', 'windsurf')),
+      detect: () => pathExists(join(home, '.codeium', 'windsurf')),
     },
     {
       name: 'VS Code',
@@ -140,7 +165,7 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.vscode', 'mcp.json'),
       skillsDir: () => join(home, '.vscode', 'skills'),
-      detect: () => existsSync(join(home, '.vscode')),
+      detect: () => pathExists(join(home, '.vscode')),
     },
     {
       name: 'Codex',
@@ -148,7 +173,7 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.codex', 'mcp.json'),
       skillsDir: () => join(home, '.agents', 'skills'),
-      detect: () => existsSync(join(home, '.codex')) || hasCli('codex'),
+      detect: () => pathExists(join(home, '.codex')) || hasCli('codex'),
     },
     {
       name: 'Claude Desktop',
@@ -156,13 +181,13 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => {
         if (plat === 'darwin') return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
-        if (plat === 'win32') return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json');
+        if (plat === 'win32') return join(appData, 'Claude', 'claude_desktop_config.json');
         return join(home, '.config', 'Claude', 'claude_desktop_config.json');
       },
       detect: () => {
-        if (plat === 'darwin') return existsSync(join(home, 'Library', 'Application Support', 'Claude'));
-        if (plat === 'win32') return existsSync(join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), 'Claude'));
-        return existsSync(join(home, '.config', 'Claude'));
+        if (plat === 'darwin') return pathExists(join(home, 'Library', 'Application Support', 'Claude'));
+        if (plat === 'win32') return pathExists(join(appData, 'Claude'));
+        return pathExists(join(home, '.config', 'Claude'));
       },
     },
     {
@@ -171,7 +196,7 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.gemini', 'settings.json'),
       skillsDir: () => join(home, '.gemini', 'skills'),
-      detect: () => existsSync(join(home, '.gemini')) || hasCli('gemini'),
+      detect: () => pathExists(join(home, '.gemini')) || hasCli('gemini'),
     },
     {
       name: 'Amp',
@@ -179,21 +204,21 @@ function getAgentRegistry(): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.amp', 'mcp.json'),
       skillsDir: () => join(home, '.amp', 'skills'),
-      detect: () => existsSync(join(home, '.amp')),
+      detect: () => pathExists(join(home, '.amp')),
     },
     {
       name: 'Cline',
       slug: 'cline',
       method: 'json-merge',
       configPath: () => join(home, '.cline', 'mcp_settings.json'),
-      detect: () => existsSync(join(home, '.cline')),
+      detect: () => pathExists(join(home, '.cline')),
     },
     {
       name: 'Roo Code',
       slug: 'roo-code',
       method: 'json-merge',
       configPath: () => join(home, '.roo-code', 'mcp_settings.json'),
-      detect: () => existsSync(join(home, '.roo-code')),
+      detect: () => pathExists(join(home, '.roo-code')),
     },
   ];
 }
@@ -206,18 +231,23 @@ function stripJsonComments(text: string): string {
     .replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-function mergeJsonConfig(configPath: string): SetupResult {
+export function mergeJsonConfig(configPath: string, deps: JsonConfigDeps = {}): SetupResult {
   const agentName = configPath;
+  const pathExists = deps.pathExists ?? existsSync;
+  const readTextFile = deps.readTextFile ?? readFileSync;
+  const writeTextFile = deps.writeTextFile ?? writeFileSync;
+  const ensureDir = deps.ensureDir ?? mkdirSync;
+  const copyFile = deps.copyFile ?? copyFileSync;
 
   try {
-    if (!existsSync(configPath)) {
-      mkdirSync(join(configPath, '..'), { recursive: true });
+    if (!pathExists(configPath)) {
+      ensureDir(join(configPath, '..'), { recursive: true });
       const config = { mcpServers: { "hanzi-browser": MCP_ENTRY } };
-      writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+      writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
       return { agent: agentName, status: 'configured', detail: `created ${configPath}` };
     }
 
-    const raw = readFileSync(configPath, 'utf-8');
+    const raw = readTextFile(configPath, 'utf-8');
     let config: any;
     try {
       config = JSON.parse(raw);
@@ -226,9 +256,9 @@ function mergeJsonConfig(configPath: string): SetupResult {
         config = JSON.parse(stripJsonComments(raw));
       } catch {
         const bakPath = configPath + '.bak';
-        copyFileSync(configPath, bakPath);
+        copyFile(configPath, bakPath);
         config = { mcpServers: { "hanzi-browser": MCP_ENTRY } };
-        writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+        writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
         return { agent: agentName, status: 'configured', detail: `backed up malformed config to ${bakPath}` };
       }
     }
@@ -242,7 +272,7 @@ function mergeJsonConfig(configPath: string): SetupResult {
 
     if (!config.mcpServers) config.mcpServers = {};
     config.mcpServers["hanzi-browser"] = MCP_ENTRY;
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+    writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
     return { agent: agentName, status: 'configured', detail: `merged into ${configPath}` };
   } catch (err: any) {
     if (err.code === 'EACCES' || err.code === 'EPERM') {
@@ -291,19 +321,25 @@ const BROWSERS: BrowserInfo[] = [
   { name: 'Chromium',        slug: 'chromium', macApp: 'Chromium',       linuxBin: 'chromium-browser' },
 ];
 
-function detectBrowsers(): BrowserInfo[] {
-  const plat = platform();
+export function detectBrowsers(deps: BrowserDetectionDeps = {}): BrowserInfo[] {
+  const plat = deps.plat ?? platform();
+  const pathExists = deps.pathExists ?? existsSync;
+  const runCommand = deps.runCommand ?? execSync;
   return BROWSERS.filter(b => {
     if (plat === 'darwin') {
-      return existsSync(`/Applications/${b.macApp}.app`);
+      return pathExists(`/Applications/${b.macApp}.app`);
     }
     try {
-      execSync(`which ${b.linuxBin}`, { stdio: 'ignore' });
+      runCommand(`which ${b.linuxBin}`, { stdio: 'ignore' });
       return true;
     } catch {
       return false;
     }
   });
+}
+
+export function resolveInteractiveMode(options: { yes?: boolean } = {}, stdinIsTTY = process.stdin.isTTY ?? false): boolean {
+  return options.yes ? false : stdinIsTTY;
 }
 
 function openInBrowser(browser: BrowserInfo, url: string): void {
@@ -773,7 +809,7 @@ export async function runSetup(options: { only?: string; yes?: boolean } = {}): 
 
   const registry = getAgentRegistry();
   const only = options.only;
-  const interactive = options.yes ? false : (process.stdin.isTTY ?? false);
+  const interactive = resolveInteractiveMode(options);
 
   // ── Banner ──
   if (interactive) {

--- a/server/test/detect-credentials.test.ts
+++ b/server/test/detect-credentials.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import { join } from 'path';
 import { detectCredentialSources } from '../src/cli/detect-credentials.js';
 
 describe('detectCredentialSources', () => {
   describe('Claude Code credentials', () => {
     it('detects credentials file when it exists', () => {
+      const claudePath = join('/Users/test', '.claude', '.credentials.json');
       const sources = detectCredentialSources({
         platform: 'darwin',
         homedir: '/Users/test',
-        fileExists: (p) => p === '/Users/test/.claude/.credentials.json',
+        fileExists: (p) => p === claudePath,
         keychainHas: () => false,
       });
 
@@ -15,7 +17,7 @@ describe('detectCredentialSources', () => {
       expect(claude).toEqual({
         name: 'Claude Code',
         slug: 'claude',
-        path: '/Users/test/.claude/.credentials.json',
+        path: claudePath,
       });
     });
 
@@ -35,15 +37,16 @@ describe('detectCredentialSources', () => {
     });
 
     it('prefers credentials file over Keychain when both exist', () => {
+      const claudePath = join('/Users/test', '.claude', '.credentials.json');
       const sources = detectCredentialSources({
         platform: 'darwin',
         homedir: '/Users/test',
-        fileExists: (p) => p === '/Users/test/.claude/.credentials.json',
+        fileExists: (p) => p === claudePath,
         keychainHas: () => true,
       });
 
       expect(sources.find(s => s.slug === 'claude')!.path)
-        .toBe('/Users/test/.claude/.credentials.json');
+        .toBe(claudePath);
     });
 
     it('skips Keychain check on Linux', () => {
@@ -73,17 +76,18 @@ describe('detectCredentialSources', () => {
 
   describe('Codex CLI credentials', () => {
     it('detects auth.json when it exists', () => {
+      const codexPath = join('/Users/test', '.codex', 'auth.json');
       const sources = detectCredentialSources({
         platform: 'darwin',
         homedir: '/Users/test',
-        fileExists: (p) => p === '/Users/test/.codex/auth.json',
+        fileExists: (p) => p === codexPath,
         keychainHas: () => false,
       });
 
       expect(sources.find(s => s.slug === 'codex')).toEqual({
         name: 'Codex CLI',
         slug: 'codex',
-        path: '/Users/test/.codex/auth.json',
+        path: codexPath,
       });
     });
 
@@ -101,16 +105,17 @@ describe('detectCredentialSources', () => {
 
   describe('combined detection', () => {
     it('detects both Claude (Keychain) and Codex together', () => {
+      const codexPath = join('/Users/test', '.codex', 'auth.json');
       const sources = detectCredentialSources({
         platform: 'darwin',
         homedir: '/Users/test',
-        fileExists: (p) => p === '/Users/test/.codex/auth.json',
+        fileExists: (p) => p === codexPath,
         keychainHas: (s) => s === 'Claude Code-credentials',
       });
 
       expect(sources).toHaveLength(2);
       expect(sources[0]).toMatchObject({ slug: 'claude', path: 'macOS Keychain' });
-      expect(sources[1]).toMatchObject({ slug: 'codex' });
+      expect(sources[1]).toMatchObject({ slug: 'codex', path: codexPath });
     });
 
     it('returns empty array when nothing is found', () => {

--- a/server/test/setup.test.ts
+++ b/server/test/setup.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  detectBrowsers,
+  getAgentRegistry,
+  mergeJsonConfig,
+  resolveInteractiveMode,
+} from '../src/cli/setup.js';
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'hanzi-setup-test-'));
+}
+
+describe('getAgentRegistry', () => {
+  it('detects configured agents and returns their config paths', () => {
+    const seenCommands: string[] = [];
+    const cursorDir = join('/Users/tester', '.cursor');
+    const vscodeDir = join('/Users/tester', '.vscode');
+    const claudeDesktopDir = join('/Users/tester', 'Library', 'Application Support', 'Claude');
+    const registry = getAgentRegistry({
+      home: '/Users/tester',
+      plat: 'darwin',
+      appData: '/Users/tester/AppData/Roaming',
+      pathExists: (path) => [
+        cursorDir,
+        vscodeDir,
+        claudeDesktopDir,
+      ].includes(path),
+      runCommand: (command) => {
+        seenCommands.push(command);
+        if (command === 'which claude' || command === 'which codex') {
+          return '';
+        }
+        throw new Error(`unexpected command: ${command}`);
+      },
+    });
+
+    expect(registry.find(agent => agent.slug === 'cursor')?.detect()).toBe(true);
+    expect(registry.find(agent => agent.slug === 'cursor')?.configPath?.())
+      .toBe(join('/Users/tester', '.cursor', 'mcp.json'));
+    expect(registry.find(agent => agent.slug === 'vscode')?.detect()).toBe(true);
+    expect(registry.find(agent => agent.slug === 'codex')?.detect()).toBe(true);
+    expect(registry.find(agent => agent.slug === 'claude-code')?.detect()).toBe(true);
+    expect(registry.find(agent => agent.slug === 'claude-desktop')?.configPath?.())
+      .toBe(join('/Users/tester', 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'));
+    expect(seenCommands).toContain('which claude');
+    expect(seenCommands).toContain('which codex');
+  });
+
+  it('uses the Windows APPDATA path for Claude Desktop', () => {
+    const registry = getAgentRegistry({
+      home: 'C:\\Users\\tester',
+      plat: 'win32',
+      appData: 'C:\\Users\\tester\\AppData\\Roaming',
+      pathExists: (path) => path === 'C:\\Users\\tester\\AppData\\Roaming\\Claude',
+      runCommand: () => { throw new Error('not installed'); },
+    });
+
+    const claudeDesktop = registry.find(agent => agent.slug === 'claude-desktop');
+    expect(claudeDesktop?.detect()).toBe(true);
+    expect(claudeDesktop?.configPath?.())
+      .toBe('C:\\Users\\tester\\AppData\\Roaming\\Claude\\claude_desktop_config.json');
+  });
+});
+
+describe('mergeJsonConfig', () => {
+  it('creates a new config when none exists', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'mcp.json');
+      const result = mergeJsonConfig(configPath);
+
+      expect(result.status).toBe('configured');
+      expect(readFileSync(configPath, 'utf-8')).toContain('"hanzi-browser"');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('merges into an existing config without dropping other MCP servers', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'mcp.json');
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          existing: { command: 'node', args: ['existing.js'] },
+        },
+      }, null, 2));
+
+      const result = mergeJsonConfig(configPath);
+      const merged = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect(result.status).toBe('configured');
+      expect(merged.mcpServers.existing).toEqual({ command: 'node', args: ['existing.js'] });
+      expect(merged.mcpServers['hanzi-browser']).toEqual({
+        command: 'npx',
+        args: ['-y', 'hanzi-browse'],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('backs up malformed JSON and writes a fresh config', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'mcp.json');
+      writeFileSync(configPath, '{"mcpServers": invalid json');
+
+      const result = mergeJsonConfig(configPath);
+      const repaired = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect(result.status).toBe('configured');
+      expect(result.detail).toContain('.bak');
+      expect(readFileSync(configPath + '.bak', 'utf-8')).toContain('invalid json');
+      expect(repaired.mcpServers['hanzi-browser']).toEqual({
+        command: 'npx',
+        args: ['-y', 'hanzi-browse'],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns already-configured when the MCP entry already matches', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'mcp.json');
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          'hanzi-browser': {
+            command: 'npx',
+            args: ['-y', 'hanzi-browse'],
+          },
+        },
+      }, null, 2));
+
+      const result = mergeJsonConfig(configPath);
+
+      expect(result.status).toBe('already-configured');
+      expect(result.detail).toBe(configPath);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('detectBrowsers', () => {
+  it('detects installed browsers on macOS by .app bundle', () => {
+    const browsers = detectBrowsers({
+      plat: 'darwin',
+      pathExists: (path) => [
+        '/Applications/Google Chrome.app',
+        '/Applications/Arc.app',
+      ].includes(path),
+    });
+
+    expect(browsers.map(browser => browser.slug)).toEqual(['chrome', 'arc']);
+  });
+
+  it('detects installed browsers on Linux by executable lookup', () => {
+    const browsers = detectBrowsers({
+      plat: 'linux',
+      runCommand: (command) => {
+        if (command === 'which google-chrome' || command === 'which chromium-browser') {
+          return '';
+        }
+        throw new Error('missing binary');
+      },
+    });
+
+    expect(browsers.map(browser => browser.slug)).toEqual(['chrome', 'chromium']);
+  });
+});
+
+describe('resolveInteractiveMode', () => {
+  it('forces non-interactive mode when --yes is passed', () => {
+    expect(resolveInteractiveMode({ yes: true }, true)).toBe(false);
+  });
+
+  it('uses TTY state when --yes is not passed', () => {
+    expect(resolveInteractiveMode({}, true)).toBe(true);
+    expect(resolveInteractiveMode({}, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #6.

## Summary
- expose small setup helpers for unit testing without changing setup behavior
- add tests for agent detection, JSON config merge behavior, browser detection, and interactive mode selection
- update credential detection tests to use platform-safe path expectations and run the server test suite with Vitest

## Verification
- `npm test`
- `npm run build:server`

The tests use temporary directories and injected fs/process helpers, so they do not touch real user config files.