### PR TITLE
feat: add X Marketer landing page

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -935,6 +935,10 @@
                                 <strong>social-poster</strong>
                                 <code>Draft posts and publish from your real signed-in accounts.</code>
                             </div>
+                            <a class="prompt-item" href="x-marketer.html">
+                                <strong>x-marketer</strong>
+                                <code>Find conversations on X, craft replies in your voice, and grow your presence.</code>
+                            </a>
                         </div>
                         <p style="font-size: 13px; color: var(--muted); margin-top: 14px;">Open source skills — <a href="https://github.com/hanzili/hanzi-browse/tree/main/server/skills" target="_blank" rel="noreferrer" style="color: var(--accent-dark); font-weight: 600;" aria-label="add your own (opens in new tab)">add your own</a>.</p>
 

--- a/landing/sitemap.xml
+++ b/landing/sitemap.xml
@@ -25,4 +25,9 @@
     <lastmod>2026-04-01</lastmod>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://browse.hanzilla.co/x-marketer.html</loc>
+    <lastmod>2026-03-31</lastmod>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/landing/x-marketer.html
+++ b/landing/x-marketer.html
@@ -1,0 +1,547 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grow on X/Twitter with AI — Hanzi X Marketer</title>
+
+    <meta name="description" content="Your AI agent finds high-value conversations on X, crafts authentic replies in your voice, and engages from your real signed-in browser. You approve everything before it posts.">
+    <link rel="canonical" href="https://browse.hanzilla.co/x-marketer.html">
+
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
+    <meta property="og:title" content="Grow on X/Twitter with AI — Hanzi X Marketer">
+    <meta property="og:description" content="One command. Your AI agent finds relevant conversations on X, crafts replies in your voice, and posts from your real browser. You approve every reply.">
+    <meta property="og:image" content="https://browse.hanzilla.co/og.png">
+    <meta property="og:url" content="https://browse.hanzilla.co/x-marketer.html">
+    <meta property="og:type" content="website">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Grow on X/Twitter with AI — Hanzi X Marketer">
+    <meta name="twitter:description" content="One command. Your AI agent finds relevant conversations on X, crafts replies in your voice, and posts from your real browser. You approve every reply.">
+    <meta name="twitter:image" content="https://browse.hanzilla.co/og.png">
+
+    <style>
+        :root {
+            --bg: #f7f3ea;
+            --surface: #fffdf8;
+            --surface-2: #f3ede2;
+            --ink: #1f1711;
+            --muted: #6d6256;
+            --line: #e5ddd0;
+            --accent: #ad5a34;
+            --accent-dark: #8d4524;
+            --green: #2f4a3d;
+            --shadow: 0 16px 40px rgba(54, 38, 23, 0.08);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { scroll-behavior: smooth; }
+
+        body {
+            min-height: 100vh;
+            background:
+                radial-gradient(circle at top left, rgba(233, 199, 146, 0.22), transparent 28%),
+                radial-gradient(circle at top right, rgba(154, 191, 170, 0.18), transparent 26%),
+                var(--bg);
+            color: var(--ink);
+            font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        a { color: inherit; text-decoration: none; }
+
+        .page { width: min(1120px, calc(100% - 40px)); margin: 0 auto; }
+
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 20px;
+            padding: 28px 0 18px;
+        }
+
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            font-size: 15px;
+            font-weight: 700;
+            letter-spacing: 0.01em;
+        }
+
+        .brand-mark { width: 26px; height: 26px; flex-shrink: 0; }
+
+        .header-links { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+
+        .btn, .link-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 44px;
+            padding: 0 18px;
+            border-radius: 999px;
+            border: 1px solid var(--line);
+            background: var(--surface);
+            font-size: 14px;
+            font-weight: 700;
+            transition: transform 140ms ease, background 140ms ease, border-color 140ms ease;
+        }
+
+        .btn:hover, .link-pill:hover { transform: translateY(-1px); }
+
+        .btn-primary {
+            color: #fff;
+            border-color: transparent;
+            background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+        }
+
+        h1, h2 {
+            font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+            letter-spacing: -0.05em;
+        }
+
+        /* Hero */
+        .hero {
+            display: grid;
+            grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+            gap: 42px;
+            align-items: center;
+            padding: 34px 0 44px;
+        }
+
+        h1 {
+            margin-top: 12px;
+            font-size: clamp(2.6rem, 6vw, 4.4rem);
+            line-height: 0.95;
+        }
+
+        .hero-copy p {
+            max-width: 520px;
+            margin-top: 18px;
+            font-size: 18px;
+            line-height: 1.65;
+            color: var(--muted);
+        }
+
+        .hero-copy strong { color: var(--ink); }
+
+        .eyebrow {
+            display: inline-flex;
+            align-items: center;
+            padding: 10px 14px;
+            border-radius: 999px;
+            border: 1px solid #e9d5c8;
+            background: #fcf4ee;
+            color: var(--accent-dark);
+            font-size: 12px;
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .demo-panel {
+            border: 1px solid var(--line);
+            border-radius: 24px;
+            background: var(--surface);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+        }
+
+        /* Sections */
+        .section {
+            padding: 56px 0;
+            border-top: 1px solid var(--line);
+        }
+
+        .section-kicker {
+            color: var(--accent-dark);
+            font-size: 12px;
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        h2 {
+            margin-top: 10px;
+            font-size: clamp(2.1rem, 4vw, 3.3rem);
+            line-height: 0.96;
+        }
+
+        /* Steps */
+        .steps-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 16px;
+            margin-top: 28px;
+        }
+
+        .step-card {
+            padding: 22px;
+            border: 1px solid var(--line);
+            border-radius: 22px;
+            background: var(--surface);
+        }
+
+        .step-num {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 28px;
+            height: 28px;
+            margin-bottom: 14px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+            color: #fff;
+            font-size: 13px;
+            font-weight: 800;
+        }
+
+        .step-card h3 {
+            font-size: 18px;
+            line-height: 1.2;
+            margin-bottom: 8px;
+        }
+
+        .step-card p {
+            color: var(--muted);
+            font-size: 15px;
+            line-height: 1.65;
+        }
+
+        /* Modes */
+        .goals-row {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin-top: 28px;
+        }
+
+        .goal-chip {
+            padding: 12px 18px;
+            border: 1px solid var(--line);
+            border-radius: 999px;
+            background: var(--surface);
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .goal-chip span {
+            margin-right: 6px;
+        }
+
+        /* Differentiators */
+        .diff-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 16px;
+            margin-top: 28px;
+        }
+
+        .diff-card {
+            padding: 22px;
+            border: 1px solid var(--line);
+            border-radius: 22px;
+            background: var(--surface);
+        }
+
+        .diff-card h3 {
+            font-size: 18px;
+            line-height: 1.2;
+            margin-bottom: 8px;
+        }
+
+        .diff-card p {
+            color: var(--muted);
+            font-size: 15px;
+            line-height: 1.65;
+        }
+
+        /* CTA */
+        .cta-band {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 20px;
+            align-items: center;
+            padding: 28px;
+            border: 1px solid var(--line);
+            border-radius: 22px;
+            background: linear-gradient(135deg, #fffdf8 0%, #f2eadf 100%);
+        }
+
+        .setup-copy {
+            position: relative;
+            padding: 16px 16px 18px;
+            border-radius: 16px;
+            background: #241c17;
+        }
+
+        .setup-copy pre {
+            overflow-x: auto;
+            white-space: pre-wrap;
+            word-break: break-word;
+            color: #f4e8d8;
+            font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+            font-size: 13px;
+            line-height: 1.6;
+            padding-right: 60px;
+        }
+
+        .tab-bar {
+            display: flex;
+            gap: 2px;
+            margin-bottom: 12px;
+        }
+
+        .tab {
+            padding: 6px 14px;
+            border: none;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.08);
+            color: #9a8a78;
+            font-size: 12px;
+            font-weight: 700;
+            cursor: pointer;
+            font-family: inherit;
+            transition: background 140ms ease, color 140ms ease;
+        }
+
+        .tab.active {
+            background: rgba(255, 255, 255, 0.18);
+            color: #f4e8d8;
+        }
+
+        .tab:hover { background: rgba(255, 255, 255, 0.14); }
+
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+
+        .setup-copy .dim { color: #6d5e50; }
+
+        .copy-btn {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            padding: 8px 10px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.08);
+            color: #f4e8d8;
+            font-size: 12px;
+            font-weight: 700;
+            cursor: pointer;
+            font-family: inherit;
+        }
+
+        footer {
+            display: flex;
+            justify-content: space-between;
+            gap: 18px;
+            flex-wrap: wrap;
+            padding: 30px 0 40px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .footer-links { display: flex; gap: 14px; flex-wrap: wrap; }
+
+        @media (max-width: 980px) {
+            .hero, .steps-grid, .diff-grid, .cta-band { grid-template-columns: 1fr; }
+        }
+
+        @media (max-width: 720px) {
+            .page { width: min(100% - 24px, 1120px); }
+            header { padding-top: 20px; }
+            .header-links { flex-direction: column; align-items: stretch; }
+            .btn, .link-pill { width: 100%; }
+            h1 { font-size: clamp(2.4rem, 14vw, 3.6rem); }
+            .hero-copy p { font-size: 16px; }
+            .section { padding: 44px 0; }
+            .steps-grid { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <header>
+            <a class="brand" href="index.html">
+                <svg class="brand-mark" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect width="24" height="24" rx="6" fill="#1f1711"/>
+                    <path d="M7 7v10M17 7v10M7 12h10" stroke="#fffdf8" stroke-width="2.5" stroke-linecap="round"/>
+                </svg>
+                Hanzi
+            </a>
+            <nav class="header-links" aria-label="Main navigation">
+                <a class="link-pill" href="https://github.com/hanzili/hanzi-browse" target="_blank" rel="noreferrer">GitHub</a>
+            </nav>
+        </header>
+
+        <main>
+            <section class="hero">
+                <div class="hero-copy">
+                    <div class="eyebrow">Skill</div>
+                    <h1>X/Twitter growth on autopilot.</h1>
+                    <p>One command. Your AI agent finds high-value conversations, crafts replies in your voice, and posts from your real Chrome. <strong>You approve every reply before it goes live.</strong></p>
+                    <div style="margin-top: 24px; max-width: 520px;">
+                        <div class="setup-copy" style="margin-top: 0;">
+                            <div class="tab-bar" role="tablist" aria-label="Setup mode">
+                                <button class="tab active" id="tab-mcp" role="tab" aria-selected="true" aria-controls="panel-mcp" onclick="switchTab(this, 'mcp')">Claude Code / Cursor</button>
+                                <button class="tab" id="tab-cli" role="tab" aria-selected="false" aria-controls="panel-cli" onclick="switchTab(this, 'cli')">Codex / CLI</button>
+                            </div>
+                            <div class="tab-content active" id="panel-mcp" role="tabpanel" aria-labelledby="tab-mcp" data-tab="mcp">
+                                <pre><span class="dim">$</span> npx hanzi-browse setup
+<span class="dim">$</span> /x-marketer</pre>
+                            </div>
+                            <div class="tab-content" id="panel-cli" role="tabpanel" aria-labelledby="tab-cli" data-tab="cli" hidden>
+                                <pre><span class="dim">$</span> npx hanzi-browse setup
+<span class="dim">$</span> hanzi-browser start "grow on X" --skill x-marketer</pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="demo-panel">
+                    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 24px; display: flex; align-items: center; justify-content: center; background: var(--surface-2);">
+                        <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; text-align: center; padding: 32px;">
+                            <div>
+                                <div style="font-size: 48px; margin-bottom: 16px;">&#120143;</div>
+                                <p style="font-size: 18px; font-weight: 700; color: var(--ink); margin-bottom: 8px;">AI-powered X/Twitter growth</p>
+                                <p style="font-size: 14px; color: var(--muted); max-width: 300px;">Finds conversations, researches authors, and crafts authentic replies that sound like you typed them on your phone.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section">
+                <div>
+                    <div class="section-kicker">Three modes</div>
+                    <h2>Pick your growth strategy.</h2>
+                </div>
+                <div class="goals-row">
+                    <div class="goal-chip"><span>&#128172;</span> Conversations — find people discussing pain points and reply with value</div>
+                    <div class="goal-chip"><span>&#127775;</span> Influencers — warm up large accounts with genuine engagement</div>
+                    <div class="goal-chip"><span>&#128270;</span> Brand monitoring — track mentions and respond</div>
+                </div>
+            </section>
+
+            <section class="section">
+                <div>
+                    <div class="section-kicker">How it works</div>
+                    <h2>Strategy first. Replies second.</h2>
+                </div>
+                <div class="steps-grid">
+                    <div class="step-card">
+                        <div class="step-num">1</div>
+                        <h3>Learns your product</h3>
+                        <p>Reads your website or README to understand your value prop, pain points you solve, and what makes you different. Builds a keyword strategy across five layers.</p>
+                    </div>
+                    <div class="step-card">
+                        <div class="step-num">2</div>
+                        <h3>Calibrates your voice</h3>
+                        <p>Reads your past tweets to learn how you actually talk. Saves a voice profile so every reply sounds like you, not a bot. No em dashes, no "leverage", no LinkedIn-speak.</p>
+                    </div>
+                    <div class="step-card">
+                        <div class="step-num">3</div>
+                        <h3>Searches and collects</h3>
+                        <p>Searches X for relevant conversations using your keywords. Collects tweets, scores them by relevance, timing, author quality, and reply visibility.</p>
+                    </div>
+                    <div class="step-card">
+                        <div class="step-num">4</div>
+                        <h3>Researches each author</h3>
+                        <p>Visits every qualified author's profile. Reads their bio, recent tweets, and posting style. Tailors the reply tone to match their energy.</p>
+                    </div>
+                    <div class="step-card">
+                        <div class="step-num">5</div>
+                        <h3>You approve the plan</h3>
+                        <p>Shows you a table: who they are, their tweet, your draft reply, and why this engagement matters. Nothing gets posted without your say.</p>
+                    </div>
+                    <div class="step-card">
+                        <div class="step-num">6</div>
+                        <h3>Engages one by one</h3>
+                        <p>Posts each approved reply with natural timing (45-90s gaps). Logs every engagement so it never replies to the same person twice.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section">
+                <div>
+                    <div class="section-kicker">Why this is different</div>
+                    <h2>Not a reply bot.</h2>
+                </div>
+                <div class="diff-grid">
+                    <div class="diff-card">
+                        <h3>Thinks like a marketer</h3>
+                        <p>Mixes value-only replies (40%), soft mentions (40%), and direct recommendations (20%). The ratio matters — all product plugs get you flagged as spam.</p>
+                    </div>
+                    <div class="diff-card">
+                        <h3>Sounds like a human</h3>
+                        <p>Every reply passes the "typed on my phone" test. No AI giveaways — no em dashes, no "leverage", no perfect parallel structure. Uses your actual voice.</p>
+                    </div>
+                    <div class="diff-card">
+                        <h3>Your real browser</h3>
+                        <p>Posts from your actual signed-in Chrome. No API keys, no third-party access. Stops immediately if X shows a rate limit or CAPTCHA.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section">
+                <div class="cta-band">
+                    <div>
+                        <div class="section-kicker">Get started</div>
+                        <h2>One command. Start growing.</h2>
+                    </div>
+                    <div class="setup-copy">
+                        <pre>npx hanzi-browse setup</pre>
+                        <button class="copy-btn" data-copy="npx hanzi-browse setup" onclick="copyData(this)">Copy</button>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <footer>
+            <div>Give your AI agent a real browser.</div>
+            <div class="footer-links">
+                <a href="https://github.com/hanzili/hanzi-browse" target="_blank" rel="noreferrer">GitHub</a>
+                <a href="https://www.npmjs.com/package/hanzi-browse" target="_blank" rel="noreferrer">npm</a>
+                <a href="https://chromewebstore.google.com/detail/hanzi-browse/iklpkemlmbhemkiojndpbhoakgikpmcd" target="_blank" rel="noreferrer">Chrome Web Store</a>
+                <a href="https://x.com/hanzi_li" target="_blank" rel="noreferrer">Twitter</a>
+                <a href="https://www.linkedin.com/in/hanzi-li-mcgill/" target="_blank" rel="noreferrer">LinkedIn</a>
+                <a href="mailto:hanzili0217@gmail.com">Contact</a>
+            </div>
+        </footer>
+    </div>
+
+    <script>
+        async function copyData(button) {
+            const original = button.textContent;
+            try {
+                await navigator.clipboard.writeText(button.dataset.copy || '');
+                button.textContent = 'Copied';
+            } catch (_) {
+                button.textContent = 'Copy failed';
+            }
+            setTimeout(() => {
+                button.textContent = original;
+            }, 1500);
+        }
+
+        function switchTab(button, tabId) {
+            const bar = button.closest('.setup-copy');
+            bar.querySelectorAll('.tab').forEach(t => {
+                t.classList.remove('active');
+                t.setAttribute('aria-selected', 'false');
+            });
+            bar.querySelectorAll('.tab-content').forEach(c => {
+                c.classList.remove('active');
+                c.setAttribute('hidden', '');
+            });
+            button.classList.add('active');
+            button.setAttribute('aria-selected', 'true');
+            const panel = bar.querySelector(`[data-tab="${tabId}"]`);
+            panel.classList.add('active');
+            panel.removeAttribute('hidden');
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `landing/x-marketer.html` — dedicated landing page for the x-marketer skill (closes #33)
- Added nav link in `landing/index.html` under the skills section
- Added sitemap entry in `landing/sitemap.xml`

## What's included
- OG tags + Twitter cards + meta description
- Responsive layout (desktop/tablet/mobile breakpoints at 980px and 720px)
- Tab switcher for Claude Code/Cursor vs Codex/CLI setup modes
- Copy button for setup command
- Content sourced from `server/skills/x-marketer/SKILL.md`: three growth modes, 6-step workflow, differentiators
- Matches existing visual style (same CSS variables, layout patterns as linkedin-prospector and a11y-auditor pages)

## What's missing
- [ ] Desktop + mobile screenshots — Chrome remote debugging was unavailable (Chrome 146+ requires `--user-data-dir` for `--remote-debugging-port`, which creates a fresh profile without extensions/sessions)
- [ ] Skill usage screenshot — couldn't test X Marketer skill live because it requires a signed-in X session in the browser

These will be added as a follow-up comment once Chrome debugging is resolved.

## Test plan
- [ ] Open `landing/x-marketer.html` in browser — verify layout, responsive behavior
- [ ] Verify nav link from index.html works
- [ ] Check OG tags with a social media preview tool
- [ ] Test tab switcher and copy button functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)