### PR TITLE
feat: add JSON output for CLI stop and screenshot

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -32,6 +32,13 @@ import {
   getSessionScreenshotPath,
   type SessionFileStatus,
 } from './cli/session-files.js';
+import {
+  buildScreenshotPayload,
+  buildStatusPayload,
+  buildStopPayload,
+  buildTaskCompletePayload,
+  buildTaskErrorPayload,
+} from './cli/json-output.js';
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -86,7 +93,7 @@ function handleMessage(message: any): void {
       appendSessionLog(sessionId, `[COMPLETE] ${answer}`);
       writeSessionStatus(sessionId, { status: 'complete', result: answer });
       if (jsonOutput) {
-        console.log(JSON.stringify({ session_id: sessionId, status: 'completed', result }));
+        console.log(JSON.stringify(buildTaskCompletePayload(sessionId, result)));
       } else {
         console.log(`\n[CLI] Task completed: ${sessionId}`);
         console.log(answer);
@@ -99,7 +106,7 @@ function handleMessage(message: any): void {
       appendSessionLog(sessionId, `[ERROR] ${data.error}`);
       writeSessionStatus(sessionId, { status: 'error', error: data.error });
       if (jsonOutput) {
-        console.log(JSON.stringify({ session_id: sessionId, status: 'error', error: data.error }));
+        console.log(JSON.stringify(buildTaskErrorPayload(sessionId, data.error)));
       } else {
         console.error(`\n[CLI] Task error: ${data.error}`);
       }
@@ -223,11 +230,11 @@ function cmdStatus(): void {
       console.error(`Session not found: ${sessionId}`);
       process.exit(1);
     }
-    console.log(JSON.stringify(status, jsonOutput ? undefined : null, jsonOutput ? undefined : 2));
+    console.log(JSON.stringify(buildStatusPayload(status), jsonOutput ? undefined : null, jsonOutput ? undefined : 2));
   } else {
     const allSessions = listSessions();
     if (jsonOutput) {
-      console.log(JSON.stringify(allSessions));
+      console.log(JSON.stringify(buildStatusPayload(allSessions)));
     } else if (allSessions.length === 0) {
       console.log('No sessions found.');
     } else {
@@ -306,10 +313,18 @@ async function cmdStop(): Promise<void> {
 
   if (remove) {
     deleteSessionFiles(sessionId);
-    console.log(`Session ${sessionId} stopped and removed.`);
+    if (jsonOutput) {
+      console.log(JSON.stringify(buildStopPayload(sessionId, true)));
+    } else {
+      console.log(`Session ${sessionId} stopped and removed.`);
+    }
   } else {
     writeSessionStatus(sessionId, { status: 'stopped' });
-    console.log(`Session ${sessionId} stopped.`);
+    if (jsonOutput) {
+      console.log(JSON.stringify(buildStopPayload(sessionId, false)));
+    } else {
+      console.log(`Session ${sessionId} stopped.`);
+    }
   }
   disconnectAndExit(0);
 }
@@ -320,7 +335,9 @@ async function cmdScreenshot(): Promise<void> {
   activeSessionId = requestId;
   await initConnection();
   await connection.send({ type: 'mcp_screenshot', sessionId: requestId });
-  console.log(`Screenshot requested for ${requestId}. Waiting for image...\n`);
+  if (!jsonOutput) {
+    console.log(`Screenshot requested for ${requestId}. Waiting for image...\n`);
+  }
 
   const data = await new Promise<string | null>((resolve) => {
     pendingScreenshotResolve = resolve;
@@ -338,7 +355,11 @@ async function cmdScreenshot(): Promise<void> {
 
   const screenshotPath = getSessionScreenshotPath(requestId);
   writeFileSync(screenshotPath, Buffer.from(data, 'base64'));
-  console.log(`[CLI] Screenshot saved: ${screenshotPath}`);
+  if (jsonOutput) {
+    console.log(JSON.stringify(buildScreenshotPayload(requestId, screenshotPath)));
+  } else {
+    console.log(`[CLI] Screenshot saved: ${screenshotPath}`);
+  }
   disconnectAndExit(0);
 }
 
@@ -460,6 +481,7 @@ Commands:
                             Each session gets its own browser window.
 
   status [session_id]       Show status of session(s)
+    --json                  Output machine-readable JSON
 
   message <session_id> <msg>  Send follow-up instructions to a session
                               Reuses the same browser window and page state.
@@ -469,8 +491,10 @@ Commands:
 
   stop <session_id>         Stop a session
     --remove, -r            Also delete session files
+    --json                  Output machine-readable JSON
 
   screenshot [session_id]   Take a screenshot
+    --json                  Output machine-readable JSON
 
   setup                     Auto-detect AI agents and configure MCP
     --only <agent>          Only configure one agent (claude-code, cursor, windsurf, claude-desktop)

--- a/server/src/cli/json-output.ts
+++ b/server/src/cli/json-output.ts
@@ -1,0 +1,36 @@
+import type { SessionFileStatus } from './session-files.js';
+
+export function buildTaskCompletePayload(sessionId: string, result: unknown) {
+  return {
+    session_id: sessionId,
+    status: 'completed',
+    result,
+  };
+}
+
+export function buildTaskErrorPayload(sessionId: string, error: string) {
+  return {
+    session_id: sessionId,
+    status: 'error',
+    error,
+  };
+}
+
+export function buildStatusPayload(status: SessionFileStatus | SessionFileStatus[]) {
+  return status;
+}
+
+export function buildStopPayload(sessionId: string, remove = false) {
+  return {
+    session_id: sessionId,
+    status: 'stopped',
+    removed: remove,
+  };
+}
+
+export function buildScreenshotPayload(sessionId: string, screenshotPath: string) {
+  return {
+    session_id: sessionId,
+    screenshot_path: screenshotPath,
+  };
+}

--- a/server/test/cli-json.test.ts
+++ b/server/test/cli-json.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildScreenshotPayload,
+  buildStatusPayload,
+  buildStopPayload,
+  buildTaskCompletePayload,
+  buildTaskErrorPayload,
+} from '../src/cli/json-output.js';
+
+describe('CLI JSON output helpers', () => {
+  it('builds task completion payloads', () => {
+    expect(buildTaskCompletePayload('abc123', { title: 'Example Domain' })).toEqual({
+      session_id: 'abc123',
+      status: 'completed',
+      result: { title: 'Example Domain' },
+    });
+  });
+
+  it('builds task error payloads', () => {
+    expect(buildTaskErrorPayload('abc123', 'something broke')).toEqual({
+      session_id: 'abc123',
+      status: 'error',
+      error: 'something broke',
+    });
+  });
+
+  it('passes through session status payloads unchanged', () => {
+    const status = {
+      session_id: 'abc123',
+      status: 'running',
+      task: 'Go to example.com',
+    };
+
+    expect(buildStatusPayload(status as any)).toEqual(status);
+    expect(buildStatusPayload([status] as any)).toEqual([status]);
+  });
+
+  it('builds stop payloads', () => {
+    expect(buildStopPayload('abc123')).toEqual({
+      session_id: 'abc123',
+      status: 'stopped',
+      removed: false,
+    });
+
+    expect(buildStopPayload('abc123', true)).toEqual({
+      session_id: 'abc123',
+      status: 'stopped',
+      removed: true,
+    });
+  });
+
+  it('builds screenshot payloads', () => {
+    expect(buildScreenshotPayload('abc123', '/tmp/shot.png')).toEqual({
+      session_id: 'abc123',
+      screenshot_path: '/tmp/shot.png',
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5.

## Summary
- add machine-readable JSON output for `hanzi-browser stop --json`
- add machine-readable JSON output for `hanzi-browser screenshot --json`
- centralize CLI JSON payload shapes in a small helper and add tests for the output contract
- document `--json` support in the CLI help text

## Verification
- `npm test`
- `npm run build:server`
- `node dist/cli.js status --json`

Notes:
- `start --json` and `status --json` were already present on current `main`
- this PR completes the missing `stop` / `screenshot` JSON branches without changing human-readable output