### PR TITLE
fix: add Windows browser support to setup wizard

### DIFF
--- a/server/src/cli/setup.ts
+++ b/server/src/cli/setup.ts
@@ -311,14 +311,57 @@ interface BrowserInfo {
   slug: string;
   macApp: string;       // macOS .app name
   linuxBin: string;     // Linux binary name
+  winPaths: string[];   // Windows executable paths
 }
 
 const BROWSERS: BrowserInfo[] = [
-  { name: 'Google Chrome',   slug: 'chrome',  macApp: 'Google Chrome',   linuxBin: 'google-chrome' },
-  { name: 'Brave',           slug: 'brave',   macApp: 'Brave Browser',   linuxBin: 'brave-browser' },
-  { name: 'Microsoft Edge',  slug: 'edge',    macApp: 'Microsoft Edge',  linuxBin: 'microsoft-edge' },
-  { name: 'Arc',             slug: 'arc',     macApp: 'Arc',             linuxBin: 'arc' },
-  { name: 'Chromium',        slug: 'chromium', macApp: 'Chromium',       linuxBin: 'chromium-browser' },
+  {
+    name: 'Google Chrome',
+    slug: 'chrome',
+    macApp: 'Google Chrome',
+    linuxBin: 'google-chrome',
+    winPaths: [
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    ],
+  },
+  {
+    name: 'Brave',
+    slug: 'brave',
+    macApp: 'Brave Browser',
+    linuxBin: 'brave-browser',
+    winPaths: [
+      'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+      'C:\\Program Files (x86)\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+    ],
+  },
+  {
+    name: 'Microsoft Edge',
+    slug: 'edge',
+    macApp: 'Microsoft Edge',
+    linuxBin: 'microsoft-edge',
+    winPaths: [
+      'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+      'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+    ],
+  },
+  {
+    name: 'Arc',
+    slug: 'arc',
+    macApp: 'Arc',
+    linuxBin: 'arc',
+    winPaths: [],
+  },
+  {
+    name: 'Chromium',
+    slug: 'chromium',
+    macApp: 'Chromium',
+    linuxBin: 'chromium-browser',
+    winPaths: [
+      'C:\\Program Files\\Chromium\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe',
+    ],
+  },
 ];
 
 export function detectBrowsers(deps: BrowserDetectionDeps = {}): BrowserInfo[] {
@@ -328,6 +371,9 @@ export function detectBrowsers(deps: BrowserDetectionDeps = {}): BrowserInfo[] {
   return BROWSERS.filter(b => {
     if (plat === 'darwin') {
       return pathExists(`/Applications/${b.macApp}.app`);
+    }
+    if (plat === 'win32') {
+      return b.winPaths.some(path => pathExists(path));
     }
     try {
       runCommand(`which ${b.linuxBin}`, { stdio: 'ignore' });
@@ -342,17 +388,31 @@ export function resolveInteractiveMode(options: { yes?: boolean } = {}, stdinIsT
   return options.yes ? false : stdinIsTTY;
 }
 
+export function buildBrowserOpenCommand(browser: BrowserInfo, url: string, plat: NodeJS.Platform): string {
+  if (plat === 'darwin') {
+    return `open -a "${browser.macApp}" "${url}"`;
+  }
+  if (plat === 'win32') {
+    const exePath = browser.winPaths.find(path => existsSync(path)) ?? browser.winPaths[0];
+    if (!exePath) return `cmd /c start "" "${url}"`;
+    return `cmd /c start "" "${exePath}" "${url}"`;
+  }
+  return `${browser.linuxBin} "${url}" &`;
+}
+
+export function buildSystemOpenCommand(url: string, plat: NodeJS.Platform): string {
+  if (plat === 'darwin') return `open "${url}"`;
+  if (plat === 'win32') return `cmd /c start "" "${url}"`;
+  return `xdg-open "${url}"`;
+}
+
 function openInBrowser(browser: BrowserInfo, url: string): void {
   const plat = platform();
   try {
-    if (plat === 'darwin') {
-      execSync(`open -a "${browser.macApp}" "${url}"`, { stdio: 'ignore' });
-    } else {
-      execSync(`${browser.linuxBin} "${url}" &`, { stdio: 'ignore' });
-    }
+    execSync(buildBrowserOpenCommand(browser, url, plat), { stdio: 'ignore' });
   } catch {
     // Fallback: system default
-    execSync(`open "${url}" 2>/dev/null || xdg-open "${url}" 2>/dev/null`, { stdio: 'ignore' });
+    execSync(buildSystemOpenCommand(url, plat), { stdio: 'ignore' });
   }
 }
 

--- a/server/test/setup.test.ts
+++ b/server/test/setup.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
+  buildBrowserOpenCommand,
+  buildSystemOpenCommand,
   detectBrowsers,
   getAgentRegistry,
   mergeJsonConfig,
@@ -172,6 +174,37 @@ describe('detectBrowsers', () => {
     });
 
     expect(browsers.map(browser => browser.slug)).toEqual(['chrome', 'chromium']);
+  });
+
+  it('detects installed browsers on Windows by executable paths', () => {
+    const browsers = detectBrowsers({
+      plat: 'win32',
+      pathExists: (path) => [
+        'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+        'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+      ].includes(path),
+    });
+
+    expect(browsers.map(browser => browser.slug)).toEqual(['chrome', 'edge']);
+  });
+});
+
+describe('browser open commands', () => {
+  it('builds a Windows browser launch command with the detected executable', () => {
+    const command = buildBrowserOpenCommand({
+      name: 'Google Chrome',
+      slug: 'chrome',
+      macApp: 'Google Chrome',
+      linuxBin: 'google-chrome',
+      winPaths: ['C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'],
+    }, 'https://example.com', 'win32');
+
+    expect(command).toBe('cmd /c start "" "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" "https://example.com"');
+  });
+
+  it('builds a Windows fallback command for system default browser', () => {
+    expect(buildSystemOpenCommand('https://example.com', 'win32'))
+      .toBe('cmd /c start "" "https://example.com"');
   });
 });
 


### PR DESCRIPTION
Fixes #4.

## Summary
- add Windows executable path detection for Chrome, Edge, Brave, and Chromium in the setup wizard
- use Windows-specific browser launch commands for opening the Chrome Web Store during setup
- add unit tests for Windows browser detection and command construction

## Verification
- `npm test`
- `npm run build:server`
- real Windows runtime check: `detectBrowsers()` returned `["chrome","edge"]` on the test machine

This keeps the existing macOS/Linux behavior intact while filling the Windows-specific gaps in `detectBrowsers()` and `openInBrowser()`.