### PR TITLE
fix: detect additional editors in setup wizard

### DIFF
--- a/server/src/cli/setup.ts
+++ b/server/src/cli/setup.ts
@@ -29,6 +29,7 @@ interface AgentConfig {
   method: 'json-merge' | 'cli-command';
   detect: () => boolean;
   configPath?: () => string;
+  configSection?: 'mcpServers' | 'servers' | 'context_servers';
   cliCommand?: string;
   skillsDir?: () => string;
 }
@@ -125,6 +126,7 @@ export function getAgentRegistry(deps: AgentRegistryDeps = {}): AgentConfig[] {
   const home = deps.home ?? homedir();
   const plat = deps.plat ?? platform();
   const appData = deps.appData ?? process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME ?? join(home, '.config');
   const pathExists = deps.pathExists ?? existsSync;
   const runCommand = deps.runCommand ?? execSync;
 
@@ -164,8 +166,33 @@ export function getAgentRegistry(deps: AgentRegistryDeps = {}): AgentConfig[] {
       slug: 'vscode',
       method: 'json-merge',
       configPath: () => join(home, '.vscode', 'mcp.json'),
+      configSection: 'servers',
       skillsDir: () => join(home, '.vscode', 'skills'),
       detect: () => pathExists(join(home, '.vscode')),
+    },
+    {
+      name: 'Zed',
+      slug: 'zed',
+      method: 'json-merge',
+      configPath: () => {
+        if (plat === 'darwin') return join(home, 'Library', 'Application Support', 'Zed', 'settings.json');
+        if (plat === 'win32') return join(appData, 'Zed', 'settings.json');
+        return join(xdgConfigHome, 'zed', 'settings.json');
+      },
+      configSection: 'context_servers',
+      detect: () => {
+        if (plat === 'darwin') return pathExists(join(home, 'Library', 'Application Support', 'Zed'));
+        if (plat === 'win32') return pathExists(join(appData, 'Zed'));
+        return pathExists(join(xdgConfigHome, 'zed'));
+      },
+    },
+    {
+      name: 'Neovim',
+      slug: 'neovim',
+      method: 'json-merge',
+      configPath: () => join(xdgConfigHome, 'mcphub', 'servers.json'),
+      configSection: 'servers',
+      detect: () => pathExists(join(xdgConfigHome, 'mcphub')),
     },
     {
       name: 'Codex',
@@ -232,6 +259,14 @@ function stripJsonComments(text: string): string {
 }
 
 export function mergeJsonConfig(configPath: string, deps: JsonConfigDeps = {}): SetupResult {
+  return mergeJsonConfigAtKey(configPath, 'mcpServers', deps);
+}
+
+export function mergeJsonConfigAtKey(
+  configPath: string,
+  configSection: 'mcpServers' | 'servers' | 'context_servers',
+  deps: JsonConfigDeps = {},
+): SetupResult {
   const agentName = configPath;
   const pathExists = deps.pathExists ?? existsSync;
   const readTextFile = deps.readTextFile ?? readFileSync;
@@ -242,7 +277,7 @@ export function mergeJsonConfig(configPath: string, deps: JsonConfigDeps = {}): 
   try {
     if (!pathExists(configPath)) {
       ensureDir(join(configPath, '..'), { recursive: true });
-      const config = { mcpServers: { "hanzi-browser": MCP_ENTRY } };
+      const config = { [configSection]: { "hanzi-browser": MCP_ENTRY } };
       writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
       return { agent: agentName, status: 'configured', detail: `created ${configPath}` };
     }
@@ -257,21 +292,21 @@ export function mergeJsonConfig(configPath: string, deps: JsonConfigDeps = {}): 
       } catch {
         const bakPath = configPath + '.bak';
         copyFile(configPath, bakPath);
-        config = { mcpServers: { "hanzi-browser": MCP_ENTRY } };
+        config = { [configSection]: { "hanzi-browser": MCP_ENTRY } };
         writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
         return { agent: agentName, status: 'configured', detail: `backed up malformed config to ${bakPath}` };
       }
     }
 
-    if (config.mcpServers?.["hanzi-browser"]) {
-      const existing = config.mcpServers["hanzi-browser"];
+    if (config[configSection]?.["hanzi-browser"]) {
+      const existing = config[configSection]["hanzi-browser"];
       if (existing.command === MCP_ENTRY.command && JSON.stringify(existing.args) === JSON.stringify(MCP_ENTRY.args)) {
         return { agent: agentName, status: 'already-configured', detail: configPath };
       }
     }
 
-    if (!config.mcpServers) config.mcpServers = {};
-    config.mcpServers["hanzi-browser"] = MCP_ENTRY;
+    if (!config[configSection]) config[configSection] = {};
+    config[configSection]["hanzi-browser"] = MCP_ENTRY;
     writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
     return { agent: agentName, status: 'configured', detail: `merged into ${configPath}` };
   } catch (err: any) {
@@ -590,8 +625,9 @@ async function injectManagedKey(apiKey: string, agents: AgentConfig[]): Promise<
         if (existsSync(configPath)) {
           const raw = readFileSync(configPath, 'utf-8');
           const config = JSON.parse(raw);
-          if (config.mcpServers?.["hanzi-browser"]) {
-            config.mcpServers["hanzi-browser"] = managedEntry;
+          const configSection = agent.configSection ?? 'mcpServers';
+          if (config[configSection]?.["hanzi-browser"]) {
+            config[configSection]["hanzi-browser"] = managedEntry;
             writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
             console.log(`     ${c.green('✓')}  Updated ${agent.name} with managed API key`);
           }
@@ -910,7 +946,7 @@ export async function runSetup(options: { only?: string; yes?: boolean } = {}): 
     if (agent.method === 'cli-command') {
       result = runClaudeCodeSetup();
     } else {
-      result = mergeJsonConfig(agent.configPath!());
+      result = mergeJsonConfigAtKey(agent.configPath!(), agent.configSection ?? 'mcpServers');
     }
     results.push({ ...result, agent: agent.name });
     await sleep(150);

--- a/server/src/cli/setup.ts
+++ b/server/src/cli/setup.ts
@@ -30,6 +30,7 @@ interface AgentConfig {
   detect: () => boolean;
   configPath?: () => string;
   configSection?: 'mcpServers' | 'servers' | 'context_servers';
+  legacyConfigSections?: ('mcpServers' | 'servers' | 'context_servers')[];
   cliCommand?: string;
   skillsDir?: () => string;
 }
@@ -44,6 +45,7 @@ interface AgentRegistryDeps {
   home?: string;
   plat?: NodeJS.Platform;
   appData?: string;
+  xdgConfigHome?: string;
   pathExists?: (path: string) => boolean;
   runCommand?: (command: string, options?: any) => Buffer | string;
 }
@@ -126,7 +128,7 @@ export function getAgentRegistry(deps: AgentRegistryDeps = {}): AgentConfig[] {
   const home = deps.home ?? homedir();
   const plat = deps.plat ?? platform();
   const appData = deps.appData ?? process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
-  const xdgConfigHome = process.env.XDG_CONFIG_HOME ?? join(home, '.config');
+  const xdgConfigHome = deps.xdgConfigHome ?? process.env.XDG_CONFIG_HOME ?? join(home, '.config');
   const pathExists = deps.pathExists ?? existsSync;
   const runCommand = deps.runCommand ?? execSync;
 
@@ -167,6 +169,7 @@ export function getAgentRegistry(deps: AgentRegistryDeps = {}): AgentConfig[] {
       method: 'json-merge',
       configPath: () => join(home, '.vscode', 'mcp.json'),
       configSection: 'servers',
+      legacyConfigSections: ['mcpServers'],
       skillsDir: () => join(home, '.vscode', 'skills'),
       detect: () => pathExists(join(home, '.vscode')),
     },
@@ -262,10 +265,29 @@ export function mergeJsonConfig(configPath: string, deps: JsonConfigDeps = {}): 
   return mergeJsonConfigAtKey(configPath, 'mcpServers', deps);
 }
 
+function removeLegacyHanziEntries(
+  config: Record<string, any>,
+  configSection: 'mcpServers' | 'servers' | 'context_servers',
+  legacyConfigSections: ('mcpServers' | 'servers' | 'context_servers')[] = [],
+): boolean {
+  let changed = false;
+  for (const legacySection of legacyConfigSections) {
+    if (legacySection === configSection) continue;
+    const section = config[legacySection];
+    if (section && typeof section === 'object' && section['hanzi-browser']) {
+      delete section['hanzi-browser'];
+      changed = true;
+      if (Object.keys(section).length === 0) delete config[legacySection];
+    }
+  }
+  return changed;
+}
+
 export function mergeJsonConfigAtKey(
   configPath: string,
   configSection: 'mcpServers' | 'servers' | 'context_servers',
   deps: JsonConfigDeps = {},
+  legacyConfigSections: ('mcpServers' | 'servers' | 'context_servers')[] = [],
 ): SetupResult {
   const agentName = configPath;
   const pathExists = deps.pathExists ?? existsSync;
@@ -298,9 +320,15 @@ export function mergeJsonConfigAtKey(
       }
     }
 
+    const removedLegacyEntry = removeLegacyHanziEntries(config, configSection, legacyConfigSections);
+
     if (config[configSection]?.["hanzi-browser"]) {
       const existing = config[configSection]["hanzi-browser"];
       if (existing.command === MCP_ENTRY.command && JSON.stringify(existing.args) === JSON.stringify(MCP_ENTRY.args)) {
+        if (removedLegacyEntry) {
+          writeTextFile(configPath, JSON.stringify(config, null, 2) + '\n');
+          return { agent: agentName, status: 'configured', detail: `migrated legacy hanzi-browser entry in ${configPath}` };
+        }
         return { agent: agentName, status: 'already-configured', detail: configPath };
       }
     }
@@ -626,6 +654,7 @@ async function injectManagedKey(apiKey: string, agents: AgentConfig[]): Promise<
           const raw = readFileSync(configPath, 'utf-8');
           const config = JSON.parse(raw);
           const configSection = agent.configSection ?? 'mcpServers';
+          removeLegacyHanziEntries(config, configSection, agent.legacyConfigSections ?? []);
           if (config[configSection]?.["hanzi-browser"]) {
             config[configSection]["hanzi-browser"] = managedEntry;
             writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
@@ -946,7 +975,12 @@ export async function runSetup(options: { only?: string; yes?: boolean } = {}): 
     if (agent.method === 'cli-command') {
       result = runClaudeCodeSetup();
     } else {
-      result = mergeJsonConfigAtKey(agent.configPath!(), agent.configSection ?? 'mcpServers');
+      result = mergeJsonConfigAtKey(
+        agent.configPath!(),
+        agent.configSection ?? 'mcpServers',
+        {},
+        agent.legacyConfigSections ?? [],
+      );
     }
     results.push({ ...result, agent: agent.name });
     await sleep(150);

--- a/server/test/setup.test.ts
+++ b/server/test/setup.test.ts
@@ -6,6 +6,7 @@ import {
   detectBrowsers,
   getAgentRegistry,
   mergeJsonConfig,
+  mergeJsonConfigAtKey,
   resolveInteractiveMode,
 } from '../src/cli/setup.js';
 
@@ -62,6 +63,39 @@ describe('getAgentRegistry', () => {
     expect(claudeDesktop?.detect()).toBe(true);
     expect(claudeDesktop?.configPath?.())
       .toBe('C:\\Users\\tester\\AppData\\Roaming\\Claude\\claude_desktop_config.json');
+  });
+
+  it('detects Zed and exposes the official settings path', () => {
+    const zedDir = join('/Users/tester', 'Library', 'Application Support', 'Zed');
+    const registry = getAgentRegistry({
+      home: '/Users/tester',
+      plat: 'darwin',
+      appData: '/Users/tester/AppData/Roaming',
+      pathExists: (path) => path === zedDir,
+      runCommand: () => { throw new Error('not installed'); },
+    });
+
+    const zed = registry.find(agent => agent.slug === 'zed');
+    expect(zed?.detect()).toBe(true);
+    expect(zed?.configPath?.())
+      .toBe(join('/Users/tester', 'Library', 'Application Support', 'Zed', 'settings.json'));
+    expect(zed?.configSection).toBe('context_servers');
+  });
+
+  it('detects Neovim via mcphub.nvim and exposes the default servers path', () => {
+    const mcphubDir = join('/home/tester', '.config', 'mcphub');
+    const registry = getAgentRegistry({
+      home: '/home/tester',
+      plat: 'linux',
+      pathExists: (path) => path === mcphubDir,
+      runCommand: () => { throw new Error('not installed'); },
+    });
+
+    const neovim = registry.find(agent => agent.slug === 'neovim');
+    expect(neovim?.detect()).toBe(true);
+    expect(neovim?.configPath?.())
+      .toBe(join('/home/tester', '.config', 'mcphub', 'servers.json'));
+    expect(neovim?.configSection).toBe('servers');
   });
 });
 
@@ -141,6 +175,56 @@ describe('mergeJsonConfig', () => {
 
       expect(result.status).toBe('already-configured');
       expect(result.detail).toBe(configPath);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes to the requested config section for VS Code-style configs', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'mcp.json');
+      writeFileSync(configPath, JSON.stringify({
+        servers: {
+          existing: { command: 'node', args: ['existing.js'] },
+        },
+      }, null, 2));
+
+      const result = mergeJsonConfigAtKey(configPath, 'servers');
+      const merged = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect(result.status).toBe('configured');
+      expect(merged.servers.existing).toEqual({ command: 'node', args: ['existing.js'] });
+      expect(merged.servers['hanzi-browser']).toEqual({
+        command: 'npx',
+        args: ['-y', 'hanzi-browse'],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes to context_servers without overwriting other Zed settings', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'settings.json');
+      writeFileSync(configPath, JSON.stringify({
+        theme: 'One Light',
+        context_servers: {
+          existing: { command: 'node', args: ['existing.js'] },
+        },
+      }, null, 2));
+
+      const result = mergeJsonConfigAtKey(configPath, 'context_servers');
+      const merged = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect(result.status).toBe('configured');
+      expect(merged.theme).toBe('One Light');
+      expect(merged.context_servers.existing).toEqual({ command: 'node', args: ['existing.js'] });
+      expect(merged.context_servers['hanzi-browser']).toEqual({
+        command: 'npx',
+        args: ['-y', 'hanzi-browse'],
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/server/test/setup.test.ts
+++ b/server/test/setup.test.ts
@@ -87,6 +87,7 @@ describe('getAgentRegistry', () => {
     const registry = getAgentRegistry({
       home: '/home/tester',
       plat: 'linux',
+      xdgConfigHome: '/home/tester/.config',
       pathExists: (path) => path === mcphubDir,
       runCommand: () => { throw new Error('not installed'); },
     });
@@ -96,6 +97,26 @@ describe('getAgentRegistry', () => {
     expect(neovim?.configPath?.())
       .toBe(join('/home/tester', '.config', 'mcphub', 'servers.json'));
     expect(neovim?.configSection).toBe('servers');
+  });
+
+  it('uses injected XDG_CONFIG_HOME for Linux editor paths', () => {
+    const zedDir = join('/tmp/custom-xdg', 'zed');
+    const mcphubDir = join('/tmp/custom-xdg', 'mcphub');
+    const registry = getAgentRegistry({
+      home: '/home/tester',
+      plat: 'linux',
+      xdgConfigHome: '/tmp/custom-xdg',
+      pathExists: (path) => path === zedDir || path === mcphubDir,
+      runCommand: () => { throw new Error('not installed'); },
+    });
+
+    const zed = registry.find(agent => agent.slug === 'zed');
+    const neovim = registry.find(agent => agent.slug === 'neovim');
+
+    expect(zed?.detect()).toBe(true);
+    expect(zed?.configPath?.()).toBe(join('/tmp/custom-xdg', 'zed', 'settings.json'));
+    expect(neovim?.detect()).toBe(true);
+    expect(neovim?.configPath?.()).toBe(join('/tmp/custom-xdg', 'mcphub', 'servers.json'));
   });
 });
 
@@ -199,6 +220,36 @@ describe('mergeJsonConfig', () => {
         command: 'npx',
         args: ['-y', 'hanzi-browse'],
       });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates the Hanzi entry from mcpServers to servers for VS Code configs', () => {
+    const dir = makeTempDir();
+    try {
+      const configPath = join(dir, 'mcp.json');
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          'hanzi-browser': { command: 'npx', args: ['-y', 'hanzi-browse'] },
+          existingLegacy: { command: 'node', args: ['legacy.js'] },
+        },
+        servers: {
+          existing: { command: 'node', args: ['existing.js'] },
+        },
+      }, null, 2));
+
+      const result = mergeJsonConfigAtKey(configPath, 'servers', {}, ['mcpServers']);
+      const merged = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+      expect(result.status).toBe('configured');
+      expect(merged.servers['hanzi-browser']).toEqual({
+        command: 'npx',
+        args: ['-y', 'hanzi-browse'],
+      });
+      expect(merged.servers.existing).toEqual({ command: 'node', args: ['existing.js'] });
+      expect(merged.mcpServers['hanzi-browser']).toBeUndefined();
+      expect(merged.mcpServers.existingLegacy).toEqual({ command: 'node', args: ['legacy.js'] });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes #8.

## Summary
- add Zed detection to the setup wizard
- add Neovim detection via `mcphub.nvim`
- write MCP entries to the editor-specific config sections instead of always using `mcpServers`
  - VS Code: `servers`
  - Zed: `context_servers`
  - Neovim (`mcphub.nvim`): `servers`
- keep existing config content intact when merging

## Verification
- `npm test`
- `npm run build:server`
- verified the registry returns the expected config path + section for VS Code, Zed, and Neovim
