### PR TITLE
fix: store relay tool results in task steps

### DIFF
--- a/server/src/managed/api.ts
+++ b/server/src/managed/api.ts
@@ -70,6 +70,63 @@ function categorizeError(err: Error): string {
   return "internal";
 }
 
+type TaskStepInsertParams = {
+  taskRunId: string;
+  step: number;
+  status: string;
+  toolName?: string;
+  toolInput?: Record<string, any>;
+  output?: string;
+  screenshot?: string;
+  durationMs?: number;
+};
+
+function normalizeToolOutput(rawOutput: ToolResult["output"]): string {
+  if (typeof rawOutput === "string") return rawOutput.slice(0, 50000);
+  if (!rawOutput) return "";
+  try {
+    return JSON.stringify(rawOutput).slice(0, 50000);
+  } catch {
+    return String(rawOutput).slice(0, 50000);
+  }
+}
+
+export function buildToolResultTaskSteps(params: {
+  taskRunId: string;
+  step: number;
+  toolName: string;
+  result: ToolResult;
+  durationMs: number;
+}): TaskStepInsertParams[] {
+  const { taskRunId, step, toolName, result, durationMs } = params;
+  const taskSteps: TaskStepInsertParams[] = [];
+  const toolOutput = normalizeToolOutput(result.output);
+
+  if (toolOutput) {
+    taskSteps.push({
+      taskRunId,
+      step,
+      status: "tool_output",
+      toolName,
+      output: toolOutput,
+      durationMs,
+    });
+  }
+
+  if (result.screenshot?.data) {
+    taskSteps.push({
+      taskRunId,
+      step,
+      status: "screenshot",
+      toolName,
+      screenshot: result.screenshot.data,
+      durationMs,
+    });
+  }
+
+  return taskSteps;
+}
+
 let isSessionConnectedFn: ((id: string) => boolean) | null = null;
 let relayPort: number = 7862;
 
@@ -386,16 +443,15 @@ async function handleRelayCreateTask(message: any) {
     executeTool: async (toolName: string, toolInput: Record<string, any>) => {
       const startMs = Date.now();
       const result = await executeToolViaRelay(toolName, toolInput, browserSessionId);
-      // Save screenshot from tool result (best-effort)
-      if (result.screenshot?.data) {
-        S.insertTaskStep({
-          taskRunId: taskRun.id,
-          step: currentStep,
-          status: "screenshot",
-          toolName,
-          screenshot: result.screenshot.data,
-          durationMs: Date.now() - startMs,
-        }).catch(() => {});
+      const durationMs = Date.now() - startMs;
+      for (const taskStep of buildToolResultTaskSteps({
+        taskRunId: taskRun.id,
+        step: currentStep,
+        toolName,
+        result,
+        durationMs,
+      })) {
+        S.insertTaskStep(taskStep).catch(() => {});
       }
       return result;
     },
@@ -762,31 +818,14 @@ async function handleCreateTask(
       const startMs = Date.now();
       const result = await executeToolViaRelay(toolName, toolInput, browser_session_id);
       const durationMs = Date.now() - startMs;
-      // Save tool result content (best-effort) — enables browsing log access via GET /v1/tasks/:id/steps
-      const rawOutput = result.output;
-      const toolOutput = typeof rawOutput === "string" ? rawOutput
-        : rawOutput ? JSON.stringify(rawOutput).slice(0, 50000)
-        : "";
-      if (toolOutput) {
-        S.insertTaskStep({
-          taskRunId: taskRun.id,
-          step: currentStep,
-          status: "tool_output",
-          toolName,
-          output: toolOutput.slice(0, 50000), // cap at 50KB per step
-          durationMs,
-        }).catch(() => {});
-      }
-      // Save screenshot from tool result
-      if (result.screenshot?.data) {
-        S.insertTaskStep({
-          taskRunId: taskRun.id,
-          step: currentStep,
-          status: "screenshot",
-          toolName,
-          screenshot: result.screenshot.data,
-          durationMs,
-        }).catch(() => {});
+      for (const taskStep of buildToolResultTaskSteps({
+        taskRunId: taskRun.id,
+        step: currentStep,
+        toolName,
+        result,
+        durationMs,
+      })) {
+        S.insertTaskStep(taskStep).catch(() => {});
       }
       return result;
     },
@@ -1821,13 +1860,14 @@ export async function runInternalTask(params: {
       url,
       executeTool: async (toolName: string, toolInput: Record<string, any>) => {
         const result = await executeToolViaRelay(toolName, toolInput, browserSessionId);
-        // Save tool output for browsing log
-        const rawOutput = result.output;
-        const toolOutput = typeof rawOutput === "string" ? rawOutput
-          : rawOutput ? JSON.stringify(rawOutput).slice(0, 50000)
-          : "";
-        if (toolOutput) {
-          S.insertTaskStep({ taskRunId: taskRun.id, step: currentStep, status: "tool_output", toolName, output: toolOutput.slice(0, 50000) }).catch(() => {});
+        for (const taskStep of buildToolResultTaskSteps({
+          taskRunId: taskRun.id,
+          step: currentStep,
+          toolName,
+          result,
+          durationMs: 0,
+        })) {
+          S.insertTaskStep(taskStep).catch(() => {});
         }
         return result;
       },

--- a/server/test/task-steps.test.ts
+++ b/server/test/task-steps.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { buildToolResultTaskSteps } from '../src/managed/api.js';
+
+describe('buildToolResultTaskSteps', () => {
+  it('creates a tool_output step for string output', () => {
+    const steps = buildToolResultTaskSteps({
+      taskRunId: 'task-1',
+      step: 2,
+      toolName: 'read_page',
+      result: { output: 'page text' } as any,
+      durationMs: 123,
+    });
+
+    expect(steps).toEqual([
+      {
+        taskRunId: 'task-1',
+        step: 2,
+        status: 'tool_output',
+        toolName: 'read_page',
+        output: 'page text',
+        durationMs: 123,
+      },
+    ]);
+  });
+
+  it('creates both tool_output and screenshot steps when both exist', () => {
+    const steps = buildToolResultTaskSteps({
+      taskRunId: 'task-2',
+      step: 4,
+      toolName: 'computer',
+      result: {
+        output: { clicked: true },
+        screenshot: { data: 'base64-image' },
+      } as any,
+      durationMs: 456,
+    });
+
+    expect(steps).toEqual([
+      {
+        taskRunId: 'task-2',
+        step: 4,
+        status: 'tool_output',
+        toolName: 'computer',
+        output: JSON.stringify({ clicked: true }),
+        durationMs: 456,
+      },
+      {
+        taskRunId: 'task-2',
+        step: 4,
+        status: 'screenshot',
+        toolName: 'computer',
+        screenshot: 'base64-image',
+        durationMs: 456,
+      },
+    ]);
+  });
+
+  it('skips empty output and only keeps screenshot artifacts', () => {
+    const steps = buildToolResultTaskSteps({
+      taskRunId: 'task-3',
+      step: 1,
+      toolName: 'screenshot',
+      result: {
+        output: '',
+        screenshot: { data: 'shot' },
+      } as any,
+      durationMs: 20,
+    });
+
+    expect(steps).toEqual([
+      {
+        taskRunId: 'task-3',
+        step: 1,
+        status: 'screenshot',
+        toolName: 'screenshot',
+        screenshot: 'shot',
+        durationMs: 20,
+      },
+    ]);
+  });
+
+  it('caps oversized tool output at 50KB', () => {
+    const steps = buildToolResultTaskSteps({
+      taskRunId: 'task-4',
+      step: 9,
+      toolName: 'read_console_messages',
+      result: { output: 'x'.repeat(60000) } as any,
+      durationMs: 99,
+    });
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].status).toBe('tool_output');
+    expect(steps[0].output).toHaveLength(50000);
+  });
+});


### PR DESCRIPTION
Fixes #40.

## Summary

This change finishes the part of `#40` that is still missing on current `main`.

I checked the latest code first before changing anything:
- the API key / REST task creation path in `server/src/managed/api.ts` already persists `tool_output`
- the relay / sidepanel task creation path still only persisted screenshots

That meant `GET /v1/tasks/:id/steps` could include tool results for one task execution path, but not for the other one.

## What changed

- added a small shared helper in `server/src/managed/api.ts` to normalize tool result persistence
- made the relay / sidepanel task path persist both:
  - `status: "tool_output"`
  - `status: "screenshot"`
- switched the existing REST path to the same helper so the behavior stays aligned
- switched the internal task path to the same helper as well to avoid future drift
- added unit tests covering:
  - string tool output
  - structured JSON tool output
  - screenshot-only tool results
  - 50KB output truncation

## Why this is useful

Without this, browsing logs are incomplete depending on how the task was created.

After this change, tool results are stored consistently across task execution paths, which makes `task_steps` and browsing log access much more useful for debugging and observability.

## Verification

Ran locally in `server/`:
- `npm test`
- `npm run build:server`

Results:
- `27/27` tests passed
- TypeScript build passed
