### PR TITLE
docs: add data-extractor skill to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Skills are markdown files (`SKILL.md`) that teach AI agents when and how to use 
 | `social-poster` | Post to LinkedIn/X/Reddit |
 | `linkedin-prospector` | Find and connect with prospects |
 | `a11y-auditor` | Run accessibility audits |
+| `data-extractor` | Extract structured data from websites into CSV/JSON |
 | `x-marketer` | X/Twitter marketing |
 
 Each skill can also be built as a free tool (web app). The skill provides instructions for local agents; the free tool provides a hosted UI for anyone.


### PR DESCRIPTION
## Summary
- Add missing `data-extractor` skill to the skills table in CLAUDE.md
- The skill directory already exists at `server/skills/data-extractor/` but was not documented

Closes #76

## Test plan
- [x] Verify skill description matches SKILL.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)