### PR TITLE
fix: remove debug console.error calls from auth path

### DIFF
--- a/server/src/managed/auth.ts
+++ b/server/src/managed/auth.ts
@@ -176,13 +176,11 @@ export async function resolveSessionProfile(
     // Extract session token from cookie (handles both __Secure- and plain prefix)
     const cookieHeader = req.headers.cookie || '';
     const tokenMatch = cookieHeader.match(/better-auth[.\-]session_token=([^;]+)/);
-    console.error(`[AUTH] step1: match=${!!tokenMatch} cookieLen=${cookieHeader.length}`);
     if (!tokenMatch) return null;
 
     // Token format: "rawToken.signature" — we only need the raw token for DB lookup
     const rawValue = decodeURIComponent(tokenMatch[1]);
     const token = rawValue.split('.')[0];
-    console.error(`[AUTH] step2: token=${token.substring(0, 10)}... rawLen=${rawValue.length}`);
     if (!token) return null;
 
     const db = getProvisionPool();
@@ -193,12 +191,10 @@ export async function resolveSessionProfile(
        WHERE s.token = $1 LIMIT 1`,
       [token]
     );
-    console.error(`[AUTH] step3: rows=${sessionRes.rows.length}`);
     if (sessionRes.rows.length === 0) return null;
 
     const row = sessionRes.rows[0];
     // Check expiry
-    console.error(`[AUTH] step4: userId=${row.userId} expires=${row.expiresAt} expired=${new Date(row.expiresAt) < new Date()}`);
     if (new Date(row.expiresAt) < new Date()) return null;
 
     const wsRes = await db.query(
@@ -209,7 +205,6 @@ export async function resolveSessionProfile(
        ORDER BY wm.created_at ASC LIMIT 1`,
       [row.userId]
     );
-    console.error(`[AUTH] step5: wsRows=${wsRes.rows.length}`);
     if (wsRes.rows.length === 0) return null;
 
     return {


### PR DESCRIPTION
## Summary
- Remove 5 `console.error` debug lines from `resolveSessionProfile()` in `server/src/managed/auth.ts`
- These fired on every authenticated request, leaking user IDs, token prefixes, and row counts to stderr

Closes #74

## Test plan
- [x] Verify only debug lines removed, no logic changes
- [ ] Confirm auth still works after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)