### PR TITLE
fix: correct linkedin-prospector.html SEO metadata

### DIFF
--- a/landing/linkedin-prospector.html
+++ b/landing/linkedin-prospector.html
@@ -5,12 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automate LinkedIn Prospecting with AI — Hanzi</title>
 
+    <link rel="canonical" href="https://browse.hanzilla.co/linkedin-prospector.html">
+
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
 
     <meta property="og:title" content="Automate LinkedIn Prospecting with AI — Hanzi">
     <meta property="og:description" content="One command. Your AI agent finds prospects, reads their posts, and sends personalized connection requests — using your real Chrome browser.">
     <meta property="og:image" content="https://browse.hanzilla.co/og.png">
-    <meta property="og:url" content="https://browse.hanzilla.co/linkedin-prospector">
+    <meta property="og:url" content="https://browse.hanzilla.co/linkedin-prospector.html">
     <meta property="og:type" content="website">
 
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## Summary
- Add `.html` extension to `og:url` meta tag (was missing, inconsistent with other pages)
- Add missing `<link rel="canonical">` tag (all other landing pages have this)

Closes #75

## Test plan
- [x] Verify og:url and canonical now match pattern in e2e-tester.html and x-marketer.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)