### PR TITLE
feat: add Zed editor detection to setup wizard

### DIFF
--- a/server/src/cli/setup.ts
+++ b/server/src/cli/setup.ts
@@ -207,6 +207,19 @@ export function getAgentRegistry(deps: AgentRegistryDeps = {}): AgentConfig[] {
       detect: () => pathExists(join(home, '.amp')),
     },
     {
+      name: 'Zed',
+      slug: 'zed',
+      method: 'json-merge',
+      configPath: () => {
+        if (plat === 'darwin') return join(home, 'Library', 'Application Support', 'Zed', 'settings.json');
+        return join(home, '.config', 'zed', 'settings.json');
+      },
+      detect: () => {
+        if (plat === 'darwin') return pathExists(join(home, 'Library', 'Application Support', 'Zed'));
+        return pathExists(join(home, '.config', 'zed'));
+      },
+    },
+    {
       name: 'Cline',
       slug: 'cline',
       method: 'json-merge',


### PR DESCRIPTION
## Summary
- Adds Zed editor detection to `getAgentRegistry()` in `server/src/cli/setup.ts`
- Platform-aware config paths: macOS (`~/Library/Application Support/Zed/settings.json`) and Linux (`~/.config/zed/settings.json`)
- VS Code was already supported (added previously)
- Neovim omitted — no standard MCP config path exists

Closes #8

## Test plan
- [ ] Run `npx hanzi-browse setup` on macOS with Zed installed — verify it's detected
- [ ] Run setup without Zed installed — verify it's not listed
- [ ] Verify existing editors (Claude Code, Cursor, VS Code, etc.) still detected correctly