### PR TITLE
fix: add missing SEO meta tags to landing pages

### DIFF
--- a/landing/docs.html
+++ b/landing/docs.html
@@ -8,6 +8,19 @@
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-C8MZTXW947');</script>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <meta name="description" content="Hanzi developer documentation. Browser automation for AI agents — install locally or integrate via API.">
+    <link rel="canonical" href="https://browse.hanzilla.co/docs.html">
+
+    <meta property="og:title" content="Docs - Hanzi">
+    <meta property="og:description" content="Hanzi developer documentation. Browser automation for AI agents — install locally or integrate via API.">
+    <meta property="og:image" content="https://browse.hanzilla.co/og.png">
+    <meta property="og:url" content="https://browse.hanzilla.co/docs.html">
+    <meta property="og:type" content="website">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Docs - Hanzi">
+    <meta name="twitter:description" content="Hanzi developer documentation. Browser automation for AI agents — install locally or integrate via API.">
+    <meta name="twitter:image" content="https://browse.hanzilla.co/og.png">
+
     <style>
         :root {
             --bg: #f7f3ea; --surface: #fffdf8; --ink: #1f1711; --muted: #6d6256;

--- a/landing/linkedin-prospector.html
+++ b/landing/linkedin-prospector.html
@@ -5,12 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automate LinkedIn Prospecting with AI — Hanzi</title>
 
+    <meta name="description" content="One command. Your AI agent finds prospects, reads their posts, and sends personalized connection requests — using your real Chrome browser.">
+    <link rel="canonical" href="https://browse.hanzilla.co/linkedin-prospector.html">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
 
     <meta property="og:title" content="Automate LinkedIn Prospecting with AI — Hanzi">
     <meta property="og:description" content="One command. Your AI agent finds prospects, reads their posts, and sends personalized connection requests — using your real Chrome browser.">
     <meta property="og:image" content="https://browse.hanzilla.co/og.png">
-    <meta property="og:url" content="https://browse.hanzilla.co/linkedin-prospector">
+    <meta property="og:url" content="https://browse.hanzilla.co/linkedin-prospector.html">
     <meta property="og:type" content="website">
 
     <meta name="twitter:card" content="summary_large_image">

--- a/landing/pricing.html
+++ b/landing/pricing.html
@@ -3,7 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="refresh" content="0;url=index.html#pricing">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pricing - Hanzi</title>
+    <meta name="description" content="Simple pricing for Hanzi browser automation. Free BYOM plan or pay-per-task managed option.">
+    <link rel="canonical" href="https://browse.hanzilla.co/pricing.html">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
+    <meta property="og:title" content="Pricing - Hanzi">
+    <meta property="og:description" content="Simple pricing for Hanzi browser automation. Free BYOM plan or pay-per-task managed option.">
+    <meta property="og:image" content="https://browse.hanzilla.co/og.png">
+    <meta property="og:url" content="https://browse.hanzilla.co/pricing.html">
+    <meta property="og:type" content="website">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Pricing - Hanzi">
+    <meta name="twitter:description" content="Simple pricing for Hanzi browser automation. Free BYOM plan or pay-per-task managed option.">
+    <meta name="twitter:image" content="https://browse.hanzilla.co/og.png">
 </head>
 <body>
     <p>Redirecting to <a href="index.html#pricing">pricing</a>...</p>


### PR DESCRIPTION
## Summary
- **docs.html**: Added canonical URL, Open Graph tags, Twitter Card tags
- **pricing.html**: Added description, viewport, canonical, favicon, OG tags, Twitter Card tags
- **linkedin-prospector.html**: Added description, canonical URL, fixed `og:url` (was missing `.html` extension)

All tags match the pattern established in `x-marketer.html` and `e2e-tester.html`.

Closes #92

## Test plan
- [ ] Validate meta tags with [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
- [ ] Validate Twitter Card with [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [ ] Check canonical URLs resolve correctly