### PR TITLE
fix: update sitemap lastmod dates

### DIFF
--- a/landing/sitemap.xml
+++ b/landing/sitemap.xml
@@ -2,12 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://browse.hanzilla.co/</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-03-31</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://browse.hanzilla.co/docs.html</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-01</lastmod>
     <priority>0.8</priority>
   </url>
   <url>


### PR DESCRIPTION
## Summary
- Updated stale `lastmod` dates to match actual git history
  - `index.html`: 2026-03-25 → 2026-03-31
  - `docs.html`: 2026-03-25 → 2026-04-01

New landing pages (e2e-tester, x-marketer, a11y-auditor) will be added to the sitemap by their respective PRs.

Closes #93

## Test plan
- [ ] Validate sitemap at [XML Sitemap Validator](https://www.xml-sitemaps.com/validate-xml-sitemap.html)
- [ ] All `<loc>` URLs resolve to actual pages