### PR TITLE
Fix missing SEO meta tags for landing pages

### DIFF
--- a/landing/docs.html
+++ b/landing/docs.html
@@ -8,6 +8,16 @@
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-C8MZTXW947');</script>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <meta name="description" content="Hanzi developer documentation. Browser automation for AI agents — install locally or integrate via API.">
+    <link rel="canonical" href="https://browse.hanzilla.co/docs.html">
+    <meta property="og:title" content="Docs - Hanzi">
+    <meta property="og:description" content="Hanzi developer documentation. Browser automation for AI agents — install locally or integrate via API.">
+    <meta property="og:image" content="https://browse.hanzilla.co/og.png">
+    <meta property="og:url" content="https://browse.hanzilla.co/docs.html">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Docs - Hanzi">
+    <meta name="twitter:description" content="Hanzi developer documentation. Browser automation for AI agents — install locally or integrate via API.">
+    <meta name="twitter:image" content="https://browse.hanzilla.co/og.png">
     <style>
         :root {
             --bg: #f7f3ea; --surface: #fffdf8; --ink: #1f1711; --muted: #6d6256;

--- a/landing/linkedin-prospector.html
+++ b/landing/linkedin-prospector.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automate LinkedIn Prospecting with AI — Hanzi</title>
 
+    <meta name="description" content="One command. Your AI agent finds prospects, reads their posts, and sends personalized connection requests — using your real Chrome browser.">
+
     <link rel="canonical" href="https://browse.hanzilla.co/linkedin-prospector.html">
 
     <link rel="icon" type="image/svg+xml" href="favicon.svg">

--- a/landing/pricing.html
+++ b/landing/pricing.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta http-equiv="refresh" content="0;url=index.html#pricing">
     <title>Pricing - Hanzi</title>
+    <meta name="description" content="Hanzi pricing plans for browser automation API and local usage.">
+    <link rel="canonical" href="https://browse.hanzilla.co/pricing.html">
+    <meta property="og:title" content="Pricing - Hanzi">
+    <meta property="og:description" content="Hanzi pricing plans for browser automation API and local usage.">
+    <meta property="og:image" content="https://browse.hanzilla.co/og.png">
+    <meta property="og:url" content="https://browse.hanzilla.co/pricing.html">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Pricing - Hanzi">
+    <meta name="twitter:description" content="Hanzi pricing plans for browser automation API and local usage.">
+    <meta name="twitter:image" content="https://browse.hanzilla.co/og.png">
 </head>
 <body>
     <p>Redirecting to <a href="index.html#pricing">pricing</a>...</p>


### PR DESCRIPTION
Fixes #92

Added missing SEO meta tags to:
- landing/docs.html
- landing/pricing.html
- landing/linkedin-prospector.html

Also fixed the og:url in linkedin-prospector.html to use the .html path.