### PR TITLE
Add demo video to Accessibility Auditor landing page (closes #88)

### DIFF
--- a/landing/a11y-auditor.html
+++ b/landing/a11y-auditor.html
@@ -177,6 +177,24 @@
             color: var(--ink);
         }
 
+        .video-frame {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            margin-bottom: 22px;
+            border: 1px solid var(--line);
+            border-radius: 18px;
+            overflow: hidden;
+            background: #000;
+        }
+
+        .video-frame iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+            display: block;
+        }
+
         .report-item {
             padding: 12px 0;
             border-bottom: 1px solid var(--line);
@@ -465,6 +483,18 @@
                 </div>
 
                 <div class="demo-panel">
+                    <h3>Demo video</h3>
+                    <div class="video-frame">
+                        <iframe
+                            src="https://www.youtube.com/embed/qx62p8NJSj4"
+                            title="Accessibility Auditor Demo"
+                            loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin"
+                            allowfullscreen>
+                        </iframe>
+                    </div>
+
                     <h3>Sample audit report</h3>
                     <div class="report-item">
                         <span class="report-severity severity-critical">Critical</span>


### PR DESCRIPTION
## Overview

This PR adds a demo video to the **Accessibility Auditor** landing page to make the feature more immediately understandable compared to the static sample report alone.

The video demonstrates the `a11y-auditor` workflow end-to-end:
* **Running the tool** with a specific URL.
* **Opening the page** in a real browser environment.
* **Performing accessibility checks** (contrast, keyboard navigation, ARIA, etc.).
* **Generating a structured report** with screenshots and suggested fixes.

---

## Changes

- **Embedded a YouTube video** in `landing/a11y-auditor.html`.
- **Improved Visual Hierarchy**: Placed the video above the sample audit report.
- **Data Preservation**: Maintained existing report examples as a secondary reference.

---

## How to test

1.  **Start a local static server** from the repo root:
    ```bash
    python3 -m http.server 8000
    ```
2.  **Open the landing page** in your browser:
    [http://localhost:8000/landing/a11y-auditor.html](http://localhost:8000/landing/a11y-auditor.html)
3.  **Verify the following**:
    * The demo video loads and plays correctly.
    * The layout is responsive and not broken.
    * The sample audit report still renders correctly below the video.

---

## Notes

* **Hosting**: The video is hosted on YouTube (Unlisted) and embedded via `iframe`.
* **Consistency**: This implementation follows the same pattern used in other landing pages (e.g., `linkedin-prospector`, `e2e-tester`).