### PR TITLE
Fix local onboarding for Codex/Claude imports

### DIFF
--- a/native-host/install.sh
+++ b/native-host/install.sh
@@ -72,13 +72,30 @@ mkdir -p "$MANIFEST_DIR"
 
 # Extension IDs
 CHROME_STORE_ID="iklpkemlmbhemkiojndpbhoakgikpmcd"  # Production (Chrome Web Store)
-DEV_ID="dnajlkacmnpfmilkeialficajdgkkkfo"          # Development (replace with your own if different)
+DEV_ID="${1:-${HANZI_EXTENSION_ID:-}}"
+
+echo ""
+echo "Chrome extension authorization..."
+echo "  Chrome Web Store ID: $CHROME_STORE_ID"
+echo "  Unpacked extension ID is required for local development."
+echo "  Find it at chrome://extensions with Developer mode enabled."
+
+if [ -z "$DEV_ID" ]; then
+    read -r -p "Enter your unpacked Hanzi extension ID (leave blank to allow only the store build): " DEV_ID
+fi
+
+if [ -n "$DEV_ID" ] && ! [[ "$DEV_ID" =~ ^[a-z]{32}$ ]]; then
+    echo -e "${RED}✗ Invalid extension ID: $DEV_ID${NC}"
+    echo "  Expected 32 lowercase letters, e.g. abcdefghijklmnopqrstuvwxyzabcdef"
+    exit 1
+fi
 
 # Create manifest with both production and development IDs
 MANIFEST_FILE="$MANIFEST_DIR/com.hanzi_browse.oauth_host.json"
 
 echo ""
 echo "Creating manifest file..."
+if [ -n "$DEV_ID" ]; then
 cat > "$MANIFEST_FILE" << EOF
 {
   "name": "com.hanzi_browse.oauth_host",
@@ -91,8 +108,22 @@ cat > "$MANIFEST_FILE" << EOF
   ]
 }
 EOF
-
-echo -e "${GREEN}✓${NC} Configured for both production and development extensions"
+    echo -e "${GREEN}✓${NC} Configured for Chrome Web Store and unpacked extension IDs"
+else
+cat > "$MANIFEST_FILE" << EOF
+{
+  "name": "com.hanzi_browse.oauth_host",
+  "description": "Native bridge for Hanzi Browse extension (IPC between MCP server and extension)",
+  "path": "$WRAPPER_SCRIPT",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://$CHROME_STORE_ID/"
+  ]
+}
+EOF
+    echo -e "${YELLOW}⚠${NC}  Configured only for the Chrome Web Store extension"
+    echo "  Re-run with your unpacked extension ID to enable local development."
+fi
 
 if [ -f "$MANIFEST_FILE" ]; then
     echo -e "${GREEN}✓${NC} Created manifest at: $MANIFEST_FILE"

--- a/src/background/modules/codex-oauth-manager.js
+++ b/src/background/modules/codex-oauth-manager.js
@@ -9,6 +9,15 @@ import { relayRequest, isRelayConnected } from './relay-client.js';
 
 const NATIVE_HOST_NAME = 'com.hanzi_browse.oauth_host';
 
+async function saveCodexRuntimeConfig() {
+  await chrome.storage.local.set({
+    provider: 'codex',
+    apiBaseUrl: 'https://chatgpt.com/backend-api/codex/responses',
+    model: 'gpt-5.1-codex',
+    authMethod: 'codex_oauth',
+  });
+}
+
 /**
  * Import OAuth credentials from Codex CLI installation
  * Reads tokens from ~/.codex/auth.json
@@ -64,6 +73,7 @@ async function importCodexViaRelay() {
     codexAuthState: 'authenticated',
     codexTokenSource: 'codex_cli'
   });
+  await saveCodexRuntimeConfig();
 
   console.log('[Codex OAuth] ✓ Credentials saved to storage');
   return { accessToken, refreshToken, accountId };
@@ -122,6 +132,7 @@ function importCodexViaNativeHost() {
             codexAuthState: 'authenticated',
             codexTokenSource: 'codex_cli'
           });
+          await saveCodexRuntimeConfig();
 
           console.log('[Codex OAuth] ✓ Credentials saved to storage');
 

--- a/src/background/modules/mcp-bridge.js
+++ b/src/background/modules/mcp-bridge.js
@@ -580,6 +580,21 @@ async function handleMcpCommand(command) {
           throw new Error(`Unknown credential source: ${source}`);
         }
         const credentials = await importFn();
+        if (source === 'claude') {
+          await chrome.storage.local.set({
+            provider: 'anthropic',
+            apiBaseUrl: 'https://api.anthropic.com/v1/messages',
+            model: 'claude-sonnet-4-20250514',
+            authMethod: 'oauth',
+          });
+        } else if (source === 'codex') {
+          await chrome.storage.local.set({
+            provider: 'codex',
+            apiBaseUrl: 'https://chatgpt.com/backend-api/codex/responses',
+            model: 'gpt-5.1-codex',
+            authMethod: 'codex_oauth',
+          });
+        }
         await loadConfig();
         if (command.requestId) {
           sendToMcpRelay({ type: 'credentials_imported', requestId: command.requestId, success: true, credentials });

--- a/src/background/modules/oauth-manager.js
+++ b/src/background/modules/oauth-manager.js
@@ -20,6 +20,15 @@ import { relayRequest, isRelayConnected } from './relay-client.js';
 
 const NATIVE_HOST_NAME = 'com.hanzi_browse.oauth_host';
 
+async function saveClaudeRuntimeConfig() {
+  await chrome.storage.local.set({
+    provider: 'anthropic',
+    apiBaseUrl: 'https://api.anthropic.com/v1/messages',
+    model: 'claude-sonnet-4-20250514',
+    authMethod: 'oauth',
+  });
+}
+
 /**
  * Generate cryptographically random string for PKCE
  * @param {number} length - Length of random string
@@ -120,6 +129,7 @@ async function importCLIViaRelay() {
     oauthState: 'authenticated',
     tokenSource: 'claude_cli'
   });
+  await saveClaudeRuntimeConfig();
 
   console.log('[OAuth] ✓ Credentials saved to storage');
   return { accessToken, refreshToken, expiresAt: expiresAtTimestamp };
@@ -180,6 +190,7 @@ function importCLIViaNativeHost() {
             oauthState: 'authenticated',
             tokenSource: 'claude_cli'
           });
+          await saveClaudeRuntimeConfig();
 
           console.log('[OAuth] ✓ Credentials saved to storage');
 


### PR DESCRIPTION
## Summary

Fix two local onboarding issues that blocked the minimal CLI validation flow.

- importing Codex or Claude credentials could succeed without updating the active runtime provider config
- the native host installer relied on a hardcoded dev extension ID, which made unpacked local installs brittle

## Changes

- sync Codex credential import to runtime config
- sync Claude credential import to runtime config
- keep the MCP bridge import path aligned with the direct import paths
- update `native-host/install.sh` to accept the actual unpacked extension ID

## Result

The minimal local CLI flow works again without falling back to the default local Claude endpoint.
