### PR TITLE
Add qa-tester free tool example

### DIFF
--- a/examples/qa-tester/README.md
+++ b/examples/qa-tester/README.md
@@ -1,0 +1,123 @@
+# QA Tester
+
+A free QA testing tool that runs real-browser tests on any web app using Hanzi Browse.
+
+Paste a URL, optionally describe what your app does, and the AI crawls the page to infer your app's structure before generating a tailored test plan. Each test case is then executed by Hanzi in a real Chrome browser — clicking, submitting forms, triggering errors — and the results are compiled into a bug report with screenshots, reproduction steps, and severity ratings.
+
+## What It Does
+
+- Crawls the target URL first to infer app type and page structure
+- Generates a test plan tailored to the specific app (not generic)
+- Executes each test case in a real paired browser
+- Rates bug severity relative to what the app does (a broken checkout is Critical; a misaligned label is Low)
+- Returns a structured report grouped by severity with screenshots and repro steps
+
+## Architecture
+
+Follows the same two-layer pattern as `examples/a11y-audit/`:
+
+- The client owns UI state and drives the flow
+- The server is stateless and provides API routes
+- Browser AI (Hanzi) performs real-browser test execution
+- Strategy AI (Claude) crawls the page, plans test cases, and compiles the final report
+
+Main files:
+
+- [server.js](./server.js)
+- [index.html](./index.html)
+- [package.json](./package.json)
+
+## Requirements
+
+- Node.js 18+
+- A valid `HANZI_API_KEY`
+- Hanzi Browse Chrome extension installed and paired
+
+Optional (for LLM-backed planning and reporting):
+
+- `ANTHROPIC_API_KEY`
+- or `LLM_BASE_URL` and `LLM_MODEL`
+
+## Environment Variables
+
+Required:
+
+```bash
+export HANZI_API_KEY=hic_live_xxx
+```
+
+Optional:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-xxx
+export HANZI_API_URL=https://api.hanzilla.co
+export LLM_BASE_URL=https://api.anthropic.com
+export LLM_MODEL=claude-sonnet-4-6
+export PORT=3001
+```
+
+## Install
+
+```bash
+cd examples/qa-tester
+npm install
+```
+
+## Run
+
+```bash
+npm start
+```
+
+Then open:
+
+```
+http://localhost:3001
+```
+
+## User Flow
+
+1. Enter the app URL and an optional description
+2. Choose scope: Quick run (3 test cases) or Full run (5 test cases)
+3. Pair a browser session
+4. Watch real-time test progress
+5. Review the bug report with severity groupings and screenshots
+
+## Scope Modes
+
+**Quick run**
+
+- 3 test cases covering the core happy path
+- Best for a fast pre-deploy sanity check
+
+**Full run**
+
+- 5 test cases including error states, edge cases, and responsive layout
+- Better for more thorough coverage before a release
+
+## API Routes
+
+- `POST /api/plan` — crawls the page and generates a tailored test plan
+- `POST /api/test-case` — runs one test case in the real browser
+- `POST /api/report` — compiles all results into a final bug report
+- `GET /api/sessions` — lists browser sessions
+- `POST /api/pair` — creates a pairing URL
+
+## Severity Scale
+
+Severity is rated relative to the specific app, not in absolute terms:
+
+| Level | Meaning |
+|-------|---------|
+| Critical | App crash, data loss, or completely broken core flow |
+| High | Core flow broken but workaround exists, or significant data is wrong |
+| Medium | Degraded UX, confusing state, non-obvious failure |
+| Low | Cosmetic issue, minor inconsistency, polish gap |
+
+## Notes
+
+- The crawl-first approach (fetching the page HTML before planning) gives the strategy AI real context about app structure, improving test plan quality vs. planning from a URL alone.
+- Severity calibration is relative — the same bug may be rated differently on a portfolio site vs. an e-commerce checkout.
+- Coverage is limited to the selected scope. Common patterns (signup, forms, navigation, CRUD) are well covered; domain-specific business logic requires a more tailored description.
+- Some findings may reflect limitations in how Hanzi reads page content (via accessibility tree and `read_page`) rather than real user-facing bugs. Coordinate-based interactions still work correctly.
+- Some test cases involving complex interactions (double-click, viewport resizing, multi-step sequences) may time out or error depending on the paired browser session and network conditions.

--- a/examples/qa-tester/index.html
+++ b/examples/qa-tester/index.html
@@ -1,0 +1,931 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Free QA Tester — Real Browser Bug Detection</title>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-C8MZTXW947"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-C8MZTXW947');</script>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='6' fill='%23111f1a'/><path d='M7 8h10M7 12h6M7 16h8' stroke='%23eef5ef' stroke-width='2.5' stroke-linecap='round'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #f5f2ea;
+      --surface: rgba(255, 251, 244, 0.92);
+      --surface-strong: #fffdf8;
+      --ink: #16211d;
+      --muted: #5e6a64;
+      --line: #d9ddd3;
+      --accent: #2c5fa8;
+      --accent-2: #d86a2c;
+      --accent-dark: #1a3f78;
+      --critical: #9f2f26;
+      --critical-bg: #fff0ed;
+      --high: #a75b07;
+      --high-bg: #fff5df;
+      --medium: #1568a8;
+      --medium-bg: #edf6ff;
+      --low: #5f6572;
+      --low-bg: #f3f5f9;
+      --pass: #276044;
+      --pass-bg: #edf7f1;
+      --shadow: 0 20px 60px rgba(22, 33, 29, 0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at top left, rgba(44,95,168,0.12), transparent 28%),
+        radial-gradient(circle at top right, rgba(216,106,44,0.15), transparent 34%),
+        linear-gradient(180deg, #f8f3e9 0%, #f3efe7 100%);
+      color: var(--ink);
+      font-family: "IBM Plex Sans", sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+    a { color: inherit; }
+    button, input, textarea { font: inherit; }
+    .shell { max-width: 1120px; margin: 0 auto; padding: 24px 20px 80px; }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 28px;
+      font-size: 14px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .brand svg { width: 32px; height: 32px; flex-shrink: 0; }
+    .layout { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr); gap: 24px; align-items: start; }
+    .panel {
+      background: var(--surface);
+      border: 1px solid rgba(217,221,211,0.9);
+      border-radius: 28px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(14px);
+    }
+    .hero { padding: 34px; overflow: hidden; position: relative; }
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: auto -70px -120px auto;
+      width: 240px;
+      height: 240px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(44,95,168,0.14), transparent 65%);
+      pointer-events: none;
+    }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 0 14px;
+      border-radius: 999px;
+      background: #eef3f7;
+      color: var(--accent-dark);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    h1, h2, h3 { font-family: "Fraunces", Georgia, serif; letter-spacing: -0.03em; }
+    h1 { font-size: clamp(2.7rem, 5vw, 4.6rem); line-height: 0.92; margin-top: 18px; max-width: 12ch; }
+    .hero-sub { max-width: 620px; margin-top: 18px; color: var(--muted); font-size: 18px; line-height: 1.65; }
+    .hero-actions { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 28px; }
+    .btn {
+      min-height: 48px;
+      border: none;
+      border-radius: 14px;
+      padding: 0 20px;
+      cursor: pointer;
+      transition: transform 0.15s ease, opacity 0.15s ease, background 0.15s ease;
+    }
+    .btn:hover { transform: translateY(-1px); }
+    .btn:focus-visible { outline: 3px solid rgba(44,95,168,0.38); outline-offset: 2px; }
+    .btn-primary { background: linear-gradient(135deg, var(--accent), var(--accent-dark)); color: #fff; font-weight: 700; }
+    .btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+    .btn-full { width: 100%; justify-content: center; }
+    .btn-sm { min-height: 40px; border-radius: 12px; padding: 0 14px; font-size: 14px; }
+    .meta-note { color: var(--muted); font-size: 13px; line-height: 1.45; }
+    .sample { padding: 22px; }
+    .sample-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 16px; }
+    .sample-card {
+      background: var(--surface-strong);
+      border: 1px solid var(--line);
+      border-radius: 20px;
+      overflow: hidden;
+    }
+    .sample-shot {
+      min-height: 180px;
+      padding: 20px;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,0.5), rgba(255,255,255,0)),
+        linear-gradient(145deg, #d5e3f5, #fff7ef 48%, #f0d5c4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .sample-ui {
+      width: 100%;
+      max-width: 320px;
+      border-radius: 18px;
+      background: rgba(255,255,255,0.86);
+      border: 1px solid rgba(22,33,29,0.08);
+      box-shadow: 0 16px 34px rgba(22, 33, 29, 0.12);
+      padding: 18px;
+    }
+    .sample-ui .bar { height: 10px; border-radius: 999px; background: #dae3ef; margin-bottom: 12px; }
+    .sample-ui .muted-line { height: 8px; border-radius: 999px; background: #e6e2da; margin-bottom: 10px; }
+    .sample-ui .cta {
+      margin-top: 16px;
+      border-radius: 12px;
+      padding: 14px;
+      background: #f2f4f7;
+      color: #a9b3bb;
+      font-weight: 700;
+      text-align: center;
+      box-shadow: inset 0 0 0 1px rgba(22,33,29,0.05);
+    }
+    .sample-ui .error-state {
+      margin-top: 12px;
+      border-radius: 14px;
+      padding: 12px;
+      border: 2px dashed rgba(159,47,38,0.35);
+      background: rgba(159,47,38,0.06);
+      color: var(--critical);
+      font-size: 13px;
+    }
+    .finding-preview { padding: 18px; }
+    .severity-pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .sev-critical { background: var(--critical-bg); color: var(--critical); }
+    .sev-high { background: var(--high-bg); color: var(--high); }
+    .sev-medium { background: var(--medium-bg); color: var(--medium); }
+    .sev-low { background: var(--low-bg); color: var(--low); }
+    .setup, .working, .report { padding: 28px; }
+    .section-title { font-size: 34px; line-height: 1; margin-bottom: 10px; }
+    .section-sub { color: var(--muted); font-size: 15px; line-height: 1.6; margin-bottom: 22px; }
+    .field { margin-bottom: 18px; }
+    .field label { display: block; margin-bottom: 8px; font-size: 13px; font-weight: 700; }
+    .field input, .field textarea {
+      width: 100%;
+      min-height: 52px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: var(--surface-strong);
+      color: var(--ink);
+      resize: vertical;
+    }
+    .field textarea { min-height: 88px; }
+    .scope-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-bottom: 22px; }
+    .scope-card {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: var(--surface-strong);
+      padding: 16px;
+      cursor: pointer;
+      min-height: 130px;
+      transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+      text-align: left;
+    }
+    .scope-card:hover { transform: translateY(-1px); }
+    .scope-card.selected {
+      border-color: var(--accent);
+      box-shadow: inset 0 0 0 1px rgba(44,95,168,0.22);
+      background: #f3f7fb;
+    }
+    .scope-card h3 { font-size: 20px; margin-bottom: 6px; }
+    .scope-card p { color: var(--muted); font-size: 14px; line-height: 1.5; }
+    .list { display: grid; gap: 10px; }
+    .step-row, .check-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 12px 14px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--surface-strong);
+    }
+    .step-dot, .check-dot {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      border: 2px solid var(--line);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 700;
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+    .is-active .step-dot, .is-active .check-dot {
+      border-color: var(--accent);
+      color: var(--accent);
+      animation: pulse 1.3s infinite;
+    }
+    .is-done .step-dot, .is-done .check-dot {
+      border-color: var(--pass);
+      background: var(--pass);
+      color: #fff;
+      animation: none;
+    }
+    .is-fail .check-dot {
+      border-color: var(--critical);
+      background: var(--critical);
+      color: #fff;
+      animation: none;
+    }
+    .is-error .check-dot {
+      border-color: var(--high);
+      color: var(--high);
+      animation: none;
+    }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
+    .muted { color: var(--muted); }
+    .status-line { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 14px; font-size: 14px; color: var(--muted); }
+    .summary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin: 20px 0 24px; }
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 16px;
+      background: var(--surface-strong);
+    }
+    .metric-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
+    .metric-value { font-size: 32px; font-weight: 700; margin-top: 8px; }
+    .metric-sub { font-size: 13px; color: var(--muted); margin-top: 4px; }
+    .report-stack { display: grid; gap: 22px; }
+    .severity-section {
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: var(--surface-strong);
+      padding: 18px;
+    }
+    .severity-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+    .bug {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.8fr);
+      gap: 16px;
+      padding: 16px 0;
+      border-top: 1px solid var(--line);
+    }
+    .bug:first-of-type { border-top: none; padding-top: 0; }
+    .bug-shot {
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      overflow: hidden;
+      min-height: 150px;
+      background: #e8ece6;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .bug-shot img { display: block; width: 100%; height: 100%; object-fit: cover; }
+    .bug-shot-empty {
+      color: var(--muted);
+      font-size: 13px;
+      text-align: center;
+      padding: 20px;
+    }
+    .bug-meta { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
+    .meta-chip {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      background: #eef2ef;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .bug p { font-size: 14px; line-height: 1.6; color: var(--muted); margin-top: 8px; }
+    .bug strong { color: var(--ink); }
+    .repro-steps {
+      margin-top: 10px;
+      padding: 12px 14px;
+      background: #f5f7fa;
+      border-radius: 12px;
+      font-size: 13px;
+      line-height: 1.7;
+      color: var(--ink);
+      white-space: pre-wrap;
+    }
+    .pass-list, .priority-list { display: grid; gap: 10px; }
+    .pass-item, .priority-item {
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--surface-strong);
+      padding: 14px 16px;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+    .priority-item { background: #fff9f3; }
+    .pass-item { background: var(--pass-bg); color: var(--pass); }
+    .hidden { display: none !important; }
+    .toast {
+      position: fixed;
+      top: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--ink);
+      color: #fff;
+      padding: 10px 18px;
+      border-radius: 999px;
+      font-size: 14px;
+      z-index: 20;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease;
+    }
+    .toast.show { opacity: 1; }
+    @media (max-width: 960px) {
+      .layout { grid-template-columns: 1fr; }
+      .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .bug { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 640px) {
+      .hero, .sample, .setup, .working, .report { padding: 22px; }
+      .scope-grid, .summary-grid { grid-template-columns: 1fr; }
+      h1 { max-width: none; }
+      .hero-actions { flex-direction: column; }
+      .hero-actions .btn { width: 100%; }
+    }
+  </style>
+</head>
+<body>
+<script src="embed.js"></script>
+<script>!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init('phc_SNXFKD8YOBPvBNWWZnuCe7stDsJJNJ5WS8MujKhajIF',{api_host:'https://us.i.posthog.com',person_profiles:'anonymous'})</script>
+
+  <div class="shell">
+    <div class="brand">
+      <svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect width="24" height="24" rx="6" fill="#111f1a"/><path d="M7 8h10M7 12h6M7 16h8" stroke="#eef5ef" stroke-width="2.5" stroke-linecap="round"/></svg>
+      <span>QA Tester</span>
+    </div>
+
+    <main id="app"></main>
+  </div>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+  <script>
+    let sid = null;
+    let screen = 'landing';
+    let qaConfig = { url: '', scope: 'quick', description: '' };
+    let qaPlan = null;
+    let progress = null;
+    let report = null;
+
+    const BASE = location.pathname.replace(/\/$/, '');
+    const $ = (id) => document.getElementById(id);
+
+    function esc(value) {
+      if (value == null) return '';
+      const div = document.createElement('div');
+      div.textContent = String(value);
+      return div.innerHTML;
+    }
+
+    function toast(message) {
+      const el = $('toast');
+      el.textContent = message;
+      el.classList.add('show');
+      setTimeout(() => el.classList.remove('show'), 2500);
+    }
+
+    async function api(method, path, body) {
+      const url = path.startsWith('/') ? BASE + path : path;
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Request failed');
+      return data;
+    }
+
+    function severityClass(level) {
+      return {
+        Critical: 'sev-critical',
+        High: 'sev-high',
+        Medium: 'sev-medium',
+        Low: 'sev-low',
+      }[level] || 'sev-medium';
+    }
+
+    function saveState() {
+      localStorage.setItem('qa_tester_config', JSON.stringify(qaConfig));
+      localStorage.setItem('qa_tester_report', JSON.stringify(report));
+    }
+
+    function loadState() {
+      try { qaConfig = { ...qaConfig, ...(JSON.parse(localStorage.getItem('qa_tester_config')) || {}) }; } catch {}
+      try { report = JSON.parse(localStorage.getItem('qa_tester_report')) || null; } catch {}
+      if (report) screen = 'report';
+    }
+
+    async function checkBrowser() {
+      try {
+        const res = await api('GET', '/api/sessions');
+        const connected = (res.sessions || []).find((s) => s.status === 'connected');
+        if (connected) sid = connected.id;
+        return !!connected;
+      } catch {
+        return false;
+      }
+    }
+
+    async function ensureBrowser() {
+      if (sid) return sid;
+      if (await checkBrowser()) return sid;
+
+      return new Promise((resolve) => {
+        if (typeof HanziConnect !== 'undefined') {
+          $('app').innerHTML = `
+            <section class="panel setup">
+              <h2 class="section-title">Connect browser</h2>
+              <p class="section-sub">The QA run executes in a real paired browser so it can click buttons, submit forms, and catch JS errors.</p>
+              <div id="hanzi-pair-widget" style="max-width:440px"></div>
+              <button class="btn btn-ghost btn-full" id="refresh-connection" style="margin-top:12px">I've completed pairing</button>
+            </section>
+          `;
+          HanziConnect.mount('#hanzi-pair-widget', {
+            apiKey: 'hic_pub_proxy',
+            apiUrl: BASE,
+            purpose: 'run QA tests in a real browser',
+            onConnected: (sessionId) => {
+              sid = sessionId;
+              toast('Browser connected');
+              resolve(sid);
+            },
+            onDisconnected: () => {
+              sid = null;
+              toast('Browser disconnected');
+            }
+          });
+          $('refresh-connection').onclick = async () => {
+            $('refresh-connection').disabled = true;
+            $('refresh-connection').textContent = 'Checking...';
+            if (await checkBrowser()) {
+              toast('Browser connected');
+              resolve(sid);
+              return;
+            }
+            $('refresh-connection').disabled = false;
+            $('refresh-connection').textContent = "I've completed pairing";
+          };
+        } else {
+          $('app').innerHTML = `
+            <section class="panel setup">
+              <h2 class="section-title">Connect browser</h2>
+              <p class="section-sub">Install the Hanzi Browse extension, then pair it to run the QA tests.</p>
+              <button class="btn btn-primary" id="pair-fallback">Pair browser</button>
+              <p class="meta-note" id="pair-status" style="margin-top:12px"></p>
+            </section>
+          `;
+          $('pair-fallback').onclick = async () => {
+            const data = await api('POST', '/api/pair');
+            window.open(data.pairing_url, '_blank');
+            $('pair-status').textContent = 'Complete pairing in the new tab, then come back here.';
+            for (let i = 0; i < 60; i++) {
+              await new Promise((r) => setTimeout(r, 2000));
+              if (await checkBrowser()) {
+                toast('Browser connected');
+                resolve(sid);
+                return;
+              }
+            }
+            $('pair-status').textContent = 'Timed out waiting for connection.';
+            resolve(null);
+          };
+        }
+      });
+    }
+
+    function render() {
+      if (screen === 'landing') return renderLanding();
+      if (screen === 'setup') return renderSetup();
+      if (screen === 'working') return renderWorking();
+      if (screen === 'report') return renderReport();
+    }
+
+    function goTo(nextScreen) {
+      screen = nextScreen;
+      render();
+    }
+
+    function renderLanding() {
+      $('app').innerHTML = `
+        <div class="layout">
+          <section class="panel hero">
+            <div class="eyebrow">Real Browser QA Testing</div>
+            <h1>Paste a URL. Find real bugs.</h1>
+            <p class="hero-sub">AI crawls your app, generates a test plan for your specific flows, then executes each test in a real Chrome browser — clicking, submitting forms, triggering errors — and returns a bug report with screenshots and reproduction steps.</p>
+            <div class="hero-actions">
+              <button class="btn btn-primary" onclick="goTo('setup')">Start free QA run</button>
+              <button class="btn btn-ghost" onclick="scrollToSample()">See sample report</button>
+            </div>
+            <p class="meta-note" style="margin-top:16px">Built for indie developers and side-project creators. Quick run tests 3 core flows. Full run tests 5 flows including error states and edge cases.</p>
+          </section>
+
+          <aside class="panel sample" id="sample-report">
+            <div class="sample-header">
+              <div>
+                <div class="meta-note" style="text-transform:uppercase;letter-spacing:0.08em">Sample Bug</div>
+                <h3 style="font-size:24px;margin-top:4px">Form submits with empty required fields</h3>
+              </div>
+              <span class="severity-pill sev-high">High</span>
+            </div>
+            <div class="sample-card">
+              <div class="sample-shot">
+                <div class="sample-ui" aria-hidden="true">
+                  <div class="bar" style="width:52%"></div>
+                  <div class="muted-line" style="width:100%"></div>
+                  <div class="muted-line" style="width:70%"></div>
+                  <div class="cta">Submit</div>
+                  <div class="error-state">Submitted with blank email — no validation error shown.</div>
+                </div>
+              </div>
+              <div class="finding-preview">
+                <div class="meta-chip" style="margin-bottom:8px">Forms</div>
+                <p style="font-size:14px;line-height:1.6;color:var(--muted)">Clicking Submit with an empty email field triggers no validation. The request fires and returns a 500 error with no user-facing feedback.</p>
+                <div class="repro-steps">1. Navigate to /signup
+2. Leave email blank
+3. Click Submit
+&#8594; No error shown, 500 in console</div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      `;
+    }
+
+    function scrollToSample() {
+      const el = $('sample-report');
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    function renderSetup() {
+      $('app').innerHTML = `
+        <section class="panel setup">
+          <h2 class="section-title">QA setup</h2>
+          <p class="section-sub">Enter your app URL and a brief description. The AI will crawl the page first to understand your app structure before generating a tailored test plan.</p>
+
+          <div class="field">
+            <label for="qa-url">URL</label>
+            <input id="qa-url" type="url" inputmode="url" placeholder="https://your-app.com" value="${esc(qaConfig.url)}">
+          </div>
+
+          <div class="field">
+            <label for="qa-description">What does this app do? <span style="font-weight:400;color:var(--muted)">(optional but helps)</span></label>
+            <textarea id="qa-description" placeholder="e.g. A task manager where users create projects and assign tasks. Main flow is signup &#8594; create project &#8594; add tasks.">${esc(qaConfig.description)}</textarea>
+          </div>
+
+          <div class="field">
+            <label>Scope</label>
+            <div class="scope-grid">
+              <button class="scope-card ${qaConfig.scope === 'quick' ? 'selected' : ''}" onclick="setScope('quick')" aria-pressed="${qaConfig.scope === 'quick'}">
+                <h3>Quick run</h3>
+                <p>3 test cases covering the core happy path. Best for a fast pre-deploy sanity check.</p>
+              </button>
+              <button class="scope-card ${qaConfig.scope === 'full' ? 'selected' : ''}" onclick="setScope('full')" aria-pressed="${qaConfig.scope === 'full'}">
+                <h3>Full run</h3>
+                <p>5 test cases including error states, edge cases, and responsive layout.</p>
+              </button>
+            </div>
+          </div>
+
+          <button class="btn btn-primary btn-full" onclick="startQA()">Run QA tests</button>
+          <button class="btn btn-ghost btn-full" style="margin-top:10px" onclick="goTo('landing')">Back</button>
+        </section>
+      `;
+    }
+
+    function setScope(scope) {
+      qaConfig.scope = scope;
+      saveState();
+      renderSetup();
+    }
+
+    function renderWorking() {
+      if (!progress) return;
+      $('app').innerHTML = `
+        <section class="panel working">
+          <div class="status-line">
+            <span>${esc(progress.title)}</span>
+            <span>${esc(progress.detail || '')}</span>
+          </div>
+          <h2 class="section-title">${esc(progress.headline)}</h2>
+          <p class="section-sub">${esc(progress.subhead)}</p>
+
+          <div class="list" style="margin-bottom:18px">
+            ${(progress.steps || []).map((step, index) => `
+              <div class="step-row ${step.done ? 'is-done' : step.active ? 'is-active' : ''}">
+                <div class="step-dot">${step.done ? '&#10003;' : index + 1}</div>
+                <div>
+                  <div style="font-weight:600">${esc(step.label)}</div>
+                  ${step.note ? `<div class="meta-note" style="margin-top:4px">${esc(step.note)}</div>` : ''}
+                </div>
+              </div>
+            `).join('')}
+          </div>
+
+          ${progress.tests?.length ? `
+            <div style="margin-top:22px">
+              <div class="meta-note" style="text-transform:uppercase;letter-spacing:0.08em;margin-bottom:10px">Test cases</div>
+              <div class="list">
+                ${progress.tests.map((tc) => `
+                  <div class="check-row ${tc.status === 'pass' ? 'is-done' : tc.status === 'fail' ? 'is-fail' : tc.status === 'active' ? 'is-active' : tc.status === 'error' ? 'is-error' : ''}">
+                    <div class="check-dot">${tc.status === 'pass' ? '&#10003;' : tc.status === 'fail' ? '!' : tc.status === 'error' ? '?' : '&bull;'}</div>
+                    <div style="flex:1">
+                      <div style="font-weight:600">${esc(tc.label)}</div>
+                      <div class="meta-note" style="margin-top:4px">${esc(
+                        tc.status === 'active' ? 'Running in browser...' :
+                        tc.status === 'pass' ? (tc.bugs === 0 ? 'Passed' : tc.bugs + ' bug' + (tc.bugs > 1 ? 's' : '') + ' found') :
+                        tc.status === 'fail' ? (tc.bugs || 0) + ' bug' + ((tc.bugs || 0) !== 1 ? 's' : '') + ' found' :
+                        tc.status === 'error' ? 'Error running test' :
+                        'Waiting'
+                      )}</div>
+                    </div>
+                    ${(tc.status === 'fail' || (tc.status === 'pass' && tc.bugs > 0)) && tc.topSeverity ? `<span class="severity-pill sev-${tc.topSeverity.toLowerCase()}" style="align-self:center">${esc(tc.topSeverity)}</span>` : ''}
+                  </div>
+                `).join('')}
+              </div>
+            </div>
+          ` : ''}
+        </section>
+      `;
+    }
+
+    function updateProgress(patch) {
+      progress = { ...progress, ...patch };
+      renderWorking();
+    }
+
+    async function startQA() {
+      qaConfig.url = $('qa-url').value.trim();
+      qaConfig.description = $('qa-description').value.trim();
+      if (!qaConfig.url) return toast('Enter a URL');
+      saveState();
+
+      progress = {
+        title: 'QA run starting',
+        detail: 'Preparing',
+        headline: 'Crawling your app',
+        subhead: 'Reading the page structure to build a tailored test plan.',
+        steps: [
+          { label: 'Crawl page and generate test plan', active: true, done: false },
+          { label: 'Connect browser session', active: false, done: false },
+          { label: 'Execute test cases', active: false, done: false },
+          { label: 'Compile bug report', active: false, done: false },
+        ],
+        tests: [],
+      };
+      goTo('working');
+
+      try {
+        // Step 1: crawl + generate plan
+        const { plan } = await api('POST', '/api/plan', {
+          url: qaConfig.url,
+          scope: qaConfig.scope,
+          description: qaConfig.description,
+        });
+        qaPlan = plan;
+
+        updateProgress({
+          headline: 'Test plan ready — ' + plan.test_cases.length + ' test cases',
+          subhead: plan.app_type + ': ' + plan.app_summary,
+          detail: 'Connecting browser',
+          steps: progress.steps.map((s, i) => ({ ...s, done: i === 0, active: i === 1 })),
+          tests: plan.test_cases.map((tc) => ({ label: tc.label, status: 'waiting', bugs: 0 })),
+        });
+
+        // Step 2: connect browser
+        const sessionId = await ensureBrowser();
+        if (!sessionId) throw new Error('No browser session available. Pair a browser to continue.');
+
+        updateProgress({
+          headline: 'Running tests in real browser',
+          subhead: 'Each test case is executed by Hanzi in your paired Chrome browser.',
+          detail: 'Testing',
+          steps: progress.steps.map((s, i) => ({ ...s, done: i < 2, active: i === 2 })),
+        });
+
+        // Step 3: run each test case sequentially
+        const testResults = [];
+        for (let i = 0; i < plan.test_cases.length; i++) {
+          const tc = plan.test_cases[i];
+
+          updateProgress({
+            tests: progress.tests.map((t, j) => ({
+              ...t,
+              status: j < i ? t.status : j === i ? 'active' : 'waiting',
+            })),
+          });
+
+          try {
+            const result = await api('POST', '/api/test-case', {
+              browser_session_id: sessionId,
+              url: plan.url,
+              test_case: tc,
+              app_summary: plan.app_summary,
+            });
+            testResults.push(result);
+
+            const topSeverity = result.bugs[0]?.severity || null;
+            const hasBugs = result.bugs.length > 0;
+
+            updateProgress({
+              tests: progress.tests.map((t, j) => ({
+                ...t,
+                status: j === i ? (hasBugs ? 'fail' : 'pass') : t.status,
+                bugs: j === i ? result.bugs.length : t.bugs,
+                topSeverity: j === i ? topSeverity : t.topSeverity,
+              })),
+            });
+          } catch (err) {
+            testResults.push({ test_case: tc, bugs: [], passes: [], passed: false, error: err.message });
+            updateProgress({
+              tests: progress.tests.map((t, j) => ({
+                ...t,
+                status: j === i ? 'error' : t.status,
+              })),
+            });
+          }
+        }
+
+        // Step 4: compile report
+        updateProgress({
+          headline: 'Compiling bug report',
+          subhead: 'Summarizing findings and prioritizing bugs.',
+          detail: 'Building report',
+          steps: progress.steps.map((s, i) => ({ ...s, done: i < 3, active: i === 3 })),
+        });
+
+        const reportData = await api('POST', '/api/report', {
+          plan,
+          test_results: testResults,
+        });
+
+        report = reportData;
+        saveState();
+        goTo('report');
+      } catch (err) {
+        toast(err.message);
+        updateProgress({
+          headline: 'Something went wrong',
+          subhead: err.message,
+          detail: 'Error',
+        });
+      }
+    }
+
+    function renderReport() {
+      if (!report) return goTo('setup');
+      const { summary, grouped_bugs, passes, plan } = report;
+      const totalBugs = Object.values(grouped_bugs).flat().length;
+
+      $('app').innerHTML = `
+        <section class="panel report">
+          <div class="status-line">
+            <span>QA Report — ${esc(plan?.url)}</span>
+            <button class="btn btn-ghost btn-sm" onclick="startNew()">New run</button>
+          </div>
+
+          <h2 class="section-title">${esc(summary.headline)}</h2>
+          <p class="section-sub">${esc(summary.summary)}</p>
+
+          <div class="summary-grid">
+            <div class="metric">
+              <div class="metric-label">Bugs</div>
+              <div class="metric-value" style="color:${totalBugs > 0 ? 'var(--critical)' : 'var(--pass)'}">${totalBugs}</div>
+              <div class="metric-sub">found</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">Critical</div>
+              <div class="metric-value" style="color:${summary.severity_totals.Critical > 0 ? 'var(--critical)' : 'var(--muted)'}">${summary.severity_totals.Critical}</div>
+              <div class="metric-sub">+ ${summary.severity_totals.High} high</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">Tests run</div>
+              <div class="metric-value">${summary.tests_run}</div>
+              <div class="metric-sub">${summary.tests_passed} passed</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">Scope</div>
+              <div class="metric-value" style="font-size:20px;margin-top:12px">${esc(plan?.scope || '')}</div>
+              <div class="metric-sub">${esc(plan?.app_type || '')}</div>
+            </div>
+          </div>
+
+          ${summary.top_priorities.length ? `
+            <div style="margin-bottom:24px">
+              <div class="meta-note" style="text-transform:uppercase;letter-spacing:0.08em;margin-bottom:10px">Top priorities</div>
+              <div class="priority-list">
+                ${summary.top_priorities.map((p) => `<div class="priority-item">${esc(p)}</div>`).join('')}
+              </div>
+            </div>
+          ` : ''}
+
+          <div class="report-stack">
+            ${['Critical', 'High', 'Medium', 'Low'].map((sev) => {
+              const bugs = grouped_bugs[sev] || [];
+              if (!bugs.length) return '';
+              return `
+                <div class="severity-section">
+                  <div class="severity-header">
+                    <span class="severity-pill sev-${sev.toLowerCase()}">${sev}</span>
+                    <span class="meta-note">${bugs.length} bug${bugs.length > 1 ? 's' : ''}</span>
+                  </div>
+                  ${bugs.map((bug) => `
+                    <div class="bug">
+                      <div>
+                        <div class="bug-meta">
+                          <span class="severity-pill sev-${sev.toLowerCase()}">${sev}</span>
+                          ${bug.category ? `<span class="meta-chip">${esc(bug.category)}</span>` : ''}
+                          ${bug.test_label ? `<span class="meta-chip">${esc(bug.test_label)}</span>` : ''}
+                        </div>
+                        <strong style="font-size:15px">${esc(bug.title)}</strong>
+                        ${bug.expected ? `<p><strong>Expected:</strong> ${esc(bug.expected)}</p>` : ''}
+                        ${bug.actual ? `<p><strong>Actual:</strong> ${esc(bug.actual)}</p>` : ''}
+                        ${bug.evidence ? `<p>${esc(bug.evidence)}</p>` : ''}
+                        ${bug.steps_to_reproduce ? `<div class="repro-steps">${esc(bug.steps_to_reproduce)}</div>` : ''}
+                      </div>
+                      <div class="bug-shot">
+                        ${bug.screenshot
+                          ? `<img src="${esc(bug.screenshot)}" alt="Screenshot of bug" loading="lazy">`
+                          : `<div class="bug-shot-empty">No screenshot captured</div>`
+                        }
+                      </div>
+                    </div>
+                  `).join('')}
+                </div>
+              `;
+            }).join('')}
+
+            ${passes.length ? `
+              <div>
+                <div class="meta-note" style="text-transform:uppercase;letter-spacing:0.08em;margin-bottom:10px">Passing checks</div>
+                <div class="pass-list">
+                  ${passes.map((p) => `<div class="pass-item">&#10003; ${esc(p)}</div>`).join('')}
+                </div>
+              </div>
+            ` : ''}
+
+            ${!totalBugs ? `
+              <div style="text-align:center;padding:32px 0;color:var(--pass)">
+                <div style="font-size:48px;margin-bottom:12px">&#10003;</div>
+                <div style="font-size:18px;font-weight:700">All tested flows passed</div>
+                <div class="meta-note" style="margin-top:8px">Coverage limited to ${summary.tests_run} test case${summary.tests_run > 1 ? 's' : ''} in this run.</div>
+              </div>
+            ` : ''}
+          </div>
+
+          <div style="display:flex;gap:12px;margin-top:28px;flex-wrap:wrap">
+            <button class="btn btn-primary" onclick="startNew()">Run another test</button>
+            <button class="btn btn-ghost" onclick="downloadJSON()">Export JSON</button>
+          </div>
+        </section>
+      `;
+    }
+
+    function startNew() {
+      report = null;
+      qaPlan = null;
+      localStorage.removeItem('qa_tester_report');
+      goTo('setup');
+    }
+
+    function downloadJSON() {
+      if (!report) return;
+      const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'qa-report-' + Date.now() + '.json';
+      a.click();
+    }
+
+    loadState();
+    render();
+  </script>
+</body>
+</html>

--- a/examples/qa-tester/package.json
+++ b/examples/qa-tester/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hanzi-qa-tester",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}

--- a/examples/qa-tester/server.js
+++ b/examples/qa-tester/server.js
@@ -1,0 +1,514 @@
+import express from "express";
+import { readFileSync, existsSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { HanziClient } from "../../sdk/dist/index.js";
+
+if (!process.env.no_proxy) process.env.no_proxy = "localhost,127.0.0.1";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const app = express();
+app.use(express.json({ limit: "2mb" }));
+
+const POSTHOG_KEY = process.env.POSTHOG_API_KEY || "phc_SNXFKD8YOBPvBNWWZnuCe7stDsJJNJ5WS8MujKhajIF";
+const HANZI_KEY = process.env.HANZI_API_KEY;
+const HANZI_URL = process.env.HANZI_API_URL || "https://api.hanzilla.co";
+const LLM_KEY = process.env.ANTHROPIC_API_KEY || "ccproxy";
+const LLM_URL = process.env.LLM_BASE_URL || "https://api.anthropic.com";
+const LLM_MODEL = process.env.LLM_MODEL || "claude-sonnet-4-6";
+const PORT = process.env.PORT || 3001;
+
+if (!HANZI_KEY) {
+  console.error("Set HANZI_API_KEY");
+  process.exit(1);
+}
+
+const HTML = readFileSync(join(__dirname, "index.html"), "utf-8");
+const hanziClient = new HanziClient({ apiKey: HANZI_KEY, baseUrl: HANZI_URL });
+
+const rateLimits = new Map();
+const LIMITS = { plan: 8, test: 12, report: 8 };
+
+function track(event, properties = {}, ip) {
+  if (!POSTHOG_KEY) return;
+  fetch("https://us.i.posthog.com/capture/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      api_key: POSTHOG_KEY,
+      event,
+      distinct_id: ip || "server",
+      properties: { tool: "qa-tester", ...properties },
+    }),
+  }).catch(() => {});
+}
+
+function checkRate(req, res, action) {
+  const ip = req.ip || req.socket?.remoteAddress || "unknown";
+  const now = Date.now();
+  let entry = rateLimits.get(ip);
+  if (!entry || now - entry.reset > 86400000) {
+    entry = { plan: 0, test: 0, report: 0, reset: now };
+    rateLimits.set(ip, entry);
+  }
+  if (entry[action] >= LIMITS[action]) {
+    res.status(429).json({
+      error: `Daily limit reached (${LIMITS[action]} ${action} requests/day).`,
+    });
+    return false;
+  }
+  entry[action]++;
+  return true;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of rateLimits) {
+    if (now - entry.reset > 86400000) rateLimits.delete(ip);
+  }
+}, 3600000);
+
+function extractJSON(text) {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/i);
+  if (fenced) {
+    try { return JSON.parse(fenced[1]); } catch {}
+  }
+  const firstObj = text.match(/\{[\s\S]*\}/);
+  if (firstObj) {
+    try { return JSON.parse(firstObj[0]); } catch {}
+  }
+  return null;
+}
+
+async function llm(system, user) {
+  const res = await fetch(`${LLM_URL}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": LLM_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: LLM_MODEL,
+      max_tokens: 4096,
+      system,
+      messages: [{ role: "user", content: user }],
+    }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error?.message || JSON.stringify(data));
+  return data.content?.[0]?.text || "";
+}
+
+async function fetchPageSnapshot(url) {
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Hanzi QA Tester Preview Bot" },
+      redirect: "follow",
+    });
+    const html = await res.text();
+    return html.replace(/\s+/g, " ").slice(0, 12000);
+  } catch {
+    return "";
+  }
+}
+
+function normalizeUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.toString();
+  } catch {
+    throw new Error("Enter a valid URL including https://");
+  }
+}
+
+function severityRank(level) {
+  return { Critical: 0, High: 1, Medium: 2, Low: 3 }[level] ?? 4;
+}
+
+async function collectScreenshots(taskId, count) {
+  try {
+    const steps = await hanziClient.getTaskSteps(taskId);
+    const screenshotSteps = steps.filter((s) => s.screenshot).slice(0, Math.max(0, count));
+    const images = [];
+    for (const step of screenshotSteps) {
+      try {
+        const base64 = await hanziClient.getScreenshot(taskId, step.step);
+        images.push({
+          step: step.step,
+          image: `data:image/jpeg;base64,${base64}`,
+        });
+      } catch {}
+    }
+    return images;
+  } catch {
+    return [];
+  }
+}
+
+function buildPlanFallback(url, scope, description) {
+  const appHint = description ? `App described as: ${description}. ` : "";
+  const cases = [
+    { id: "navigation", label: "Page load and navigation", category: "Core", steps: "Load the page and check for errors, broken links, or blank states." },
+    { id: "forms", label: "Form submission and validation", category: "Core", steps: "Find and submit the main form with valid input, then with invalid input." },
+    { id: "cta", label: "Primary call-to-action flows", category: "Core", steps: "Find the main CTA button and complete the flow it initiates." },
+  ];
+  if (scope === "full") {
+    cases.push(
+      { id: "errors", label: "Error states and edge cases", category: "Resilience", steps: "Try submitting empty forms, navigating to invalid routes, and triggering error states." },
+      { id: "responsive", label: "Responsive layout and overflow", category: "UI", steps: "Check the page at mobile width (375px) for layout breakage or overflow." },
+    );
+  }
+  return {
+    app_type: "web app",
+    app_summary: appHint + "Testing common user flows.",
+    url,
+    scope,
+    test_cases: cases,
+  };
+}
+
+async function generatePlan(url, scope, description, htmlSnippet) {
+  const response = await llm(
+    `You are a QA strategist generating a practical test plan for a web application.
+Your goal is to find real bugs that would frustrate users, not pedantic edge cases.
+Severity must be rated relative to what this specific app does — a broken checkout on an e-commerce site is Critical; a misaligned label on a portfolio is Low.
+Return strict JSON only.`,
+    `Create a QA test plan for this web app.
+
+URL: ${url}
+Scope: ${scope}
+Developer's description: ${description || "not provided"}
+
+Page HTML snapshot (for context):
+<html>${htmlSnippet || "unavailable"}</html>
+
+First, infer the app type (e.g. SaaS dashboard, e-commerce store, portfolio, landing page, CRUD tool).
+Then generate test cases for the most impactful user flows.
+
+If scope is "quick", generate 3 test cases covering the core happy path.
+If scope is "full", generate 5 test cases covering core flows plus error states and edge cases.
+
+Focus on:
+- Flows that handle user data or money (signup, checkout, form submit)
+- Navigation and routing (broken links, 404s, back button)
+- JS errors or blank states after interaction
+- Form validation (empty submit, bad input, success state)
+- Responsive layout on common screen widths
+
+Return JSON:
+\`\`\`json
+{
+  "app_type": "inferred app type",
+  "app_summary": "1 sentence describing what this app does based on the HTML",
+  "url": "${url}",
+  "scope": "${scope}",
+  "test_cases": [
+    {
+      "id": "signup",
+      "label": "User signup flow",
+      "category": "Authentication",
+      "steps": "brief description of what to do"
+    }
+  ]
+}
+\`\`\`
+`
+  );
+  return extractJSON(response);
+}
+
+function testPrompt(url, testCase, appSummary) {
+  return `You are a QA tester running a real-browser test on a web application.
+
+App: ${appSummary || url}
+Test: ${testCase.label}
+${testCase.steps ? `Steps hint: ${testCase.steps}` : ""}
+
+Core rules:
+- Actually perform the test — click, type, submit, navigate. Do not just describe what you see.
+- Take a screenshot when you find a bug or reach a key state.
+- Verify issues are real before reporting them. One confirmed bug is better than five guesses.
+- Rate severity relative to what this app does, not in absolute terms:
+  - Critical: app crash, data loss, completely broken core flow (blocks the user entirely)
+  - High: core flow broken but workaround exists, or significant data is wrong
+  - Medium: degraded UX, confusing state, non-obvious failure
+  - Low: cosmetic issue, minor inconsistency, polish gap
+- Prefer 0–3 real findings over a padded list.
+- Return strict JSON only.
+
+Return JSON:
+\`\`\`json
+{
+  "test_summary": "1–2 sentence summary of what you did and what you found",
+  "passed": true,
+  "passes": ["specific thing that worked correctly"],
+  "bugs": [
+    {
+      "title": "Short bug title",
+      "severity": "Critical|High|Medium|Low",
+      "category": "e.g. Forms, Navigation, Auth, UI, Performance",
+      "steps_to_reproduce": "numbered steps to reproduce",
+      "expected": "what should happen",
+      "actual": "what actually happened",
+      "evidence": "what you observed in the browser"
+    }
+  ]
+}
+\`\`\`
+`;
+}
+
+app.get("/embed.js", (req, res) => {
+  res.setHeader("Content-Type", "application/javascript");
+  const localPath = join(__dirname, "embed.js");
+  const repoPath = join(__dirname, "../../landing/embed.js");
+  res.end(readFileSync(existsSync(localPath) ? localPath : repoPath, "utf-8"));
+});
+
+app.get("/", (req, res) => {
+  res.setHeader("Content-Type", "text/html");
+  res.end(HTML);
+});
+
+app.get("/v1/browser-sessions", async (req, res) => {
+  try {
+    const sessions = await hanziClient.listSessions();
+    res.json({
+      sessions: sessions.map((s) => ({
+        id: s.id,
+        status: s.status,
+        connected_at: s.connectedAt,
+        last_heartbeat: s.lastHeartbeat,
+        label: s.label || null,
+        external_user_id: s.externalUserId || null,
+      })),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post("/v1/browser-sessions/pair", async (req, res) => {
+  try {
+    const data = await hanziClient.createPairingToken();
+    res.json({
+      pairing_token: data.pairingToken,
+      pairing_url: `${HANZI_URL}/pair/${data.pairingToken}`,
+      expires_at: data.expiresAt,
+      expires_in_seconds: data.expiresInSeconds,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get("/api/sessions", async (req, res) => {
+  try {
+    const sessions = await hanziClient.listSessions();
+    res.json({ sessions });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post("/api/pair", async (req, res) => {
+  try {
+    const data = await hanziClient.createPairingToken();
+    res.json({ pairing_url: `${HANZI_URL}/pair/${data.pairingToken}` });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Step 1: crawl the page and generate a test plan
+app.post("/api/plan", async (req, res) => {
+  if (!checkRate(req, res, "plan")) return;
+  try {
+    const url = normalizeUrl(req.body.url || "");
+    const scope = req.body.scope === "full" ? "full" : "quick";
+    const description = (req.body.description || "").slice(0, 500);
+
+    // Crawl the page first to give the planner real context about app structure
+    const htmlSnippet = await fetchPageSnapshot(url);
+    const planned = await generatePlan(url, scope, description, htmlSnippet).catch(() => null);
+    const fallback = buildPlanFallback(url, scope, description);
+
+    const plan = {
+      id: `qa-${Date.now()}`,
+      url,
+      scope,
+      description,
+      app_type: planned?.app_type || fallback.app_type,
+      app_summary: planned?.app_summary || fallback.app_summary,
+      test_cases: (planned?.test_cases?.length ? planned.test_cases : fallback.test_cases)
+        .slice(0, scope === "full" ? 5 : 3),
+    };
+
+    track("qa_plan_created", { scope, test_count: plan.test_cases.length }, req.ip);
+    res.json({ plan });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Step 2: run one test case in the browser
+app.post("/api/test-case", async (req, res) => {
+  if (!checkRate(req, res, "test")) return;
+  try {
+    const { browser_session_id, url, test_case, app_summary } = req.body;
+    if (!browser_session_id || !test_case?.id) {
+      return res.status(400).json({ error: "browser_session_id and test_case are required" });
+    }
+
+    const task = await hanziClient.runTask({
+      browserSessionId: browser_session_id,
+      task: testPrompt(url, test_case, app_summary),
+      url,
+    }, { timeoutMs: 8 * 60 * 1000, pollIntervalMs: 3000 });
+
+    if (task.status !== "complete" || !task.answer) {
+      return res.status(500).json({ error: `Test failed: ${task.status}` });
+    }
+
+    const parsed = extractJSON(task.answer);
+    if (!parsed) {
+      return res.status(500).json({ error: "Could not parse test output" });
+    }
+
+    const bugs = Array.isArray(parsed.bugs) ? parsed.bugs : [];
+    const screenshots = await collectScreenshots(task.id, bugs.length);
+    const enrichedBugs = bugs.map((bug, index) => ({
+      ...bug,
+      severity: ["Critical", "High", "Medium", "Low"].includes(bug?.severity) ? bug.severity : "Medium",
+      screenshot: screenshots[index]?.image || null,
+      screenshot_step: screenshots[index]?.step || null,
+    }));
+
+    const result = {
+      test_case,
+      test_summary: parsed.test_summary || "",
+      passed: enrichedBugs.length === 0,
+      passes: Array.isArray(parsed.passes) ? parsed.passes : [],
+      bugs: enrichedBugs.sort((a, b) => severityRank(a.severity) - severityRank(b.severity)),
+      task_id: task.id,
+    };
+
+    track("qa_test_complete", {
+      test_id: test_case.id,
+      bugs: result.bugs.length,
+      passed: result.passed,
+    }, req.ip);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Step 3: compile all results into a final report
+app.post("/api/report", async (req, res) => {
+  if (!checkRate(req, res, "report")) return;
+  try {
+    const { plan, test_results = [] } = req.body;
+    if (!plan?.url || !Array.isArray(test_results)) {
+      return res.status(400).json({ error: "plan and test_results are required" });
+    }
+
+    const bugs = test_results.flatMap((r) =>
+      (r.bugs || []).map((b) => ({
+        ...b,
+        test_id: r.test_case?.id,
+        test_label: r.test_case?.label,
+      }))
+    );
+
+    const passes = [...new Set(test_results.flatMap((r) => r.passes || []))];
+    const severity_totals = { Critical: 0, High: 0, Medium: 0, Low: 0 };
+    for (const bug of bugs) {
+      severity_totals[bug.severity] = (severity_totals[bug.severity] || 0) + 1;
+    }
+
+    const summaryText = await llm(
+      `You are a senior QA engineer summarizing a real-browser test run for a developer.
+Be direct and actionable. Return strict JSON only.`,
+      `Summarize this QA test run.
+
+App: ${plan.app_summary || plan.url}
+Scope: ${plan.scope}
+Tests run: ${test_results.length}
+
+Bugs found:
+${JSON.stringify(bugs.map((b) => ({
+  title: b.title,
+  severity: b.severity,
+  category: b.category,
+  test: b.test_label,
+  steps: b.steps_to_reproduce,
+  expected: b.expected,
+  actual: b.actual,
+})), null, 2)}
+
+Passing checks:
+${JSON.stringify(passes, null, 2)}
+
+Return JSON:
+\`\`\`json
+{
+  "headline": "short verdict (e.g. '3 bugs found, 1 blocks core flow')",
+  "summary": "2–3 sentence summary for the developer",
+  "top_priorities": ["most important fix 1", "most important fix 2", "most important fix 3"]
+}
+\`\`\`
+`
+    ).catch(() => "");
+
+    const summary = extractJSON(summaryText) || {
+      headline: bugs.length ? `${bugs.length} bug${bugs.length > 1 ? "s" : ""} found` : "All tested flows passed",
+      summary: bugs.length
+        ? "The QA run found issues in real browser testing. Prioritize Critical and High severity bugs before shipping."
+        : "The tested flows completed without errors. Coverage is limited to the selected scope.",
+      top_priorities: bugs.slice(0, 3).map((b) => b.title),
+    };
+
+    const grouped_bugs = {
+      Critical: bugs.filter((b) => b.severity === "Critical"),
+      High: bugs.filter((b) => b.severity === "High"),
+      Medium: bugs.filter((b) => b.severity === "Medium"),
+      Low: bugs.filter((b) => b.severity === "Low"),
+    };
+
+    track("qa_report_built", {
+      scope: plan.scope,
+      bugs: bugs.length,
+      critical: severity_totals.Critical,
+    }, req.ip);
+
+    res.json({
+      plan,
+      summary: {
+        headline: summary.headline,
+        summary: summary.summary,
+        top_priorities: Array.isArray(summary.top_priorities) ? summary.top_priorities.slice(0, 3) : [],
+        severity_totals,
+        tests_run: test_results.length,
+        tests_passed: test_results.filter((r) => r.passed).length,
+      },
+      grouped_bugs,
+      passes,
+      test_results,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`
+  QA Tester — Free Tool by Hanzi Browse
+  http://localhost:${PORT}
+
+  Strategy AI: ${LLM_URL} (${LLM_MODEL})
+  Browser:     ${HANZI_URL}
+  Rate limits: ${JSON.stringify(LIMITS)}
+  `);
+});


### PR DESCRIPTION
## Summary

  - Adds `examples/qa-tester/`, addresses issue #54
  - Implements the two-layer pattern from `examples/a11y-audit/`: Strategy AI (Claude) plans and summarizes,
  Browser AI (Hanzi) executes in a real Chrome browser

  ## What it does

  1. Crawls the target URL first to infer app type and structure before generating the test plan (addresses the
  "varies wildly" concern raised in the issue; context-first planning produces better test cases than URL-only
  planning)
  2. Generates 3 - 5 tailored test cases depending on scope; up to user's choice
  3. Executes each test case in a real paired browser
  4. Rates severity relative to the specific app (a broken checkout is Critical, a misaligned label is Low)
  5. Returns a structured report grouped by severity with screenshots, repro steps, and JSON export

  ## Test plan

  - [x] Tested end-to-end against `https://todomvc.com/examples/react/dist/`
  - [x] Plan generation, test execution, and report compilation all working
  - [x] Severity grouping and JSON export working
  - [x] Follows same architecture and file structure as `examples/a11y-audit/`

  ## Notes

  - Some test cases involving complex interactions (double-click, viewport resizing, multi-step sequences) may
  time out depending on browser session and network conditions; this is to be further optimized.
  - The "High" finding on TodoMVC reflects a Hanzi accessibility tree limitation, not a real app bug; noted in
  README