### PR TITLE
fix: resolve YAML parsing error in apartment-finder/SKILL.md frontmatter

### DIFF
--- a/server/skills/apartment-finder/SKILL.md
+++ b/server/skills/apartment-finder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apartment-finder
-description: Search for apartments across multiple real estate platforms, compare listings side by side, and help submit inquiries or applications. Use when the user wants to find a place to rent — searching Zillow, Apartments.com, Craigslist, and similar sites with their real signed-in browser. Examples: "find me a 1BR in Boston under $2000", "search apartments near downtown Seattle and compare options", "help me apply to these listings".
+description: 'Search for apartments across multiple real estate platforms, compare listings side by side, and help submit inquiries or applications. Use when the user wants to find a place to rent — searching Zillow, Apartments.com, Craigslist, and similar sites with their real signed-in browser. Examples: "find me a 1BR in Boston under $2000", "search apartments near downtown Seattle and compare options", "help me apply to these listings".'
 category: life
 ---
 


### PR DESCRIPTION
This fixes a YAML parsing error in the skill.md frontmatter.

The `description` field was unquoted and contained `Examples:`, which caused the YAML parser to fail with:
`mapping values are not allowed in this context`.

The fix wraps the `description` value in single quotes so the content stays exactly the same while parsing correctly.

No functional changes.
<img width="1076" height="264" alt="Screenshot 2026-04-16 at 6 37 41 PM" src="https://github.com/user-attachments/assets/ca906bcb-ba4c-49d9-acb5-a478ed614f89" />
