### PR TITLE
test: add Chrome extension vitest baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "scripts": {
     "dev": "vite build --watch --config vite.config.js",
     "build": "vite build --config vite.config.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,json,html,css}\",\"*.{json,md}\"",
@@ -29,13 +31,17 @@
   "devDependencies": {
     "@babel/core": "^7.28.6",
     "@preact/preset-vite": "^2.8.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/preact": "^3.2.4",
     "depcheck": "^1.4.7",
     "eslint": "^8.57.0",
     "eslint-plugin-sonarjs": "^0.25.1",
+    "jsdom": "^29.0.2",
     "knip": "^5.0.0",
     "madge": "^6.1.0",
     "prettier": "^3.2.5",
-    "vite": "^5.0.12"
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
   },
   "dependencies": {
     "preact": "^10.29.0"

--- a/src/background/modules/api.test.js
+++ b/src/background/modules/api.test.js
@@ -1,0 +1,137 @@
+import {
+  abortRequest,
+  createAbortController,
+  getApiHeaders,
+  getConfig,
+  isClaudeProvider,
+  loadConfig,
+  resolveAgentDefaultConfig,
+  setConfig,
+} from './api';
+
+describe('background api config helpers', () => {
+  it('loads config from chrome storage and appends built-in skills', async () => {
+    chrome.storage.local.get.mockResolvedValueOnce({
+      apiBaseUrl: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'openai-key',
+      model: 'gpt-5',
+      provider: 'openai',
+      userSkills: [{ domain: 'example.com', skill: 'custom' }],
+    });
+
+    const cfg = await loadConfig();
+
+    expect(cfg.apiBaseUrl).toBe('https://api.openai.com/v1/chat/completions');
+    expect(cfg.provider).toBe('openai');
+    expect(cfg.userSkills).toEqual([{ domain: 'example.com', skill: 'custom' }]);
+    expect(Array.isArray(cfg.builtInSkills)).toBe(true);
+  });
+
+  it('resolves default agent config for anthropic, codex, google, openrouter, and generic providers', () => {
+    expect(resolveAgentDefaultConfig({
+      apiBaseUrl: 'https://api.anthropic.com/v1/messages',
+      apiKey: 'a',
+      authMethod: 'oauth',
+    })).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      authMethod: 'oauth',
+    });
+
+    expect(resolveAgentDefaultConfig({
+      provider: 'codex',
+      apiBaseUrl: 'https://chatgpt.com/backend-api/codex/responses',
+      authMethod: 'codex_oauth',
+    })).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.1-codex',
+      authMethod: 'codex_oauth',
+    });
+
+    expect(resolveAgentDefaultConfig({
+      apiBaseUrl: 'https://generativelanguage.googleapis.com/v1beta/models',
+      apiKey: 'g',
+    })).toMatchObject({
+      provider: 'google',
+      model: 'gemini-2.5-flash',
+    });
+
+    expect(resolveAgentDefaultConfig({
+      provider: 'openrouter',
+      apiBaseUrl: 'https://openrouter.ai/api/v1/chat/completions',
+      apiKey: 'r',
+    })).toMatchObject({
+      provider: 'openrouter',
+      model: 'qwen/qwen3-vl-235b-a22b-thinking',
+    });
+
+    expect(resolveAgentDefaultConfig({
+      provider: 'openai',
+      apiBaseUrl: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'o',
+      model: 'gpt-5',
+    })).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-5',
+    });
+  });
+
+  it('prefers explicit agent default config when present', () => {
+    const resolved = resolveAgentDefaultConfig({
+      provider: 'openai',
+      apiBaseUrl: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'o',
+      model: 'gpt-5',
+      agentDefaultConfig: {
+        provider: 'openai',
+        model: 'o3',
+        apiBaseUrl: 'https://api.openai.com/v1/chat/completions',
+        apiKey: 'override-key',
+      },
+    });
+
+    expect(resolved).toEqual({
+      provider: 'openai',
+      model: 'o3',
+      apiBaseUrl: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'override-key',
+    });
+  });
+
+  it('uses provider-specific headers and reports whether config is anthropic', async () => {
+    setConfig({
+      provider: 'anthropic',
+      apiBaseUrl: 'https://api.anthropic.com/v1/messages',
+      apiKey: 'anthropic-key',
+      authMethod: 'api_key',
+    });
+
+    expect(isClaudeProvider()).toBe(true);
+    await expect(getApiHeaders()).resolves.toMatchObject({
+      'x-api-key': 'anthropic-key',
+      'anthropic-version': '2023-06-01',
+    });
+
+    setConfig({
+      provider: 'openai',
+      apiBaseUrl: 'https://api.openai.com/v1/chat/completions',
+      apiKey: 'openai-key',
+      authMethod: 'api_key',
+    });
+
+    expect(isClaudeProvider()).toBe(false);
+    await expect(getApiHeaders()).resolves.toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer openai-key',
+    });
+  });
+
+  it('creates and aborts the active request controller', () => {
+    const controller = createAbortController();
+    expect(controller.signal.aborted).toBe(false);
+
+    abortRequest();
+    expect(controller.signal.aborted).toBe(true);
+    expect(getConfig()).toBeTruthy();
+  });
+});

--- a/src/background/utils/retry.test.js
+++ b/src/background/utils/retry.test.js
@@ -1,0 +1,43 @@
+import {
+  isDebuggerDetachedError,
+  isTabDraggingError,
+  retryWithBackoff,
+} from './retry';
+
+describe('retry utilities', () => {
+  it('retries until the function succeeds', async () => {
+    vi.useFakeTimers();
+
+    const onRetry = vi.fn();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary'))
+      .mockRejectedValueOnce(new Error('still temporary'))
+      .mockResolvedValue('ok');
+
+    const pending = retryWithBackoff(fn, { delay: 100, onRetry });
+
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry.mock.calls[0][0]).toBe(1);
+  });
+
+  it('stops immediately when shouldRetry rejects the error', async () => {
+    const error = new Error('fatal');
+    const fn = vi.fn().mockRejectedValue(error);
+    const shouldRetry = vi.fn(() => false);
+
+    await expect(retryWithBackoff(fn, { shouldRetry })).rejects.toThrow('fatal');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects known chrome-specific transient errors', () => {
+    expect(isTabDraggingError(new Error('Tab is being dragged'))).toBe(true);
+    expect(isDebuggerDetachedError(new Error('Debugger detached from target'))).toBe(true);
+    expect(isTabDraggingError(new Error('Other'))).toBe(false);
+  });
+});

--- a/src/sidepanel-preact/components/InputArea.test.jsx
+++ b/src/sidepanel-preact/components/InputArea.test.jsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/preact';
+import { InputArea } from './InputArea';
+
+describe('InputArea', () => {
+  function renderInputArea(props = {}) {
+    const defaults = {
+      isRunning: false,
+      attachedImages: [],
+      onSend: vi.fn(),
+      onStop: vi.fn(),
+      onAddImage: vi.fn(),
+      onRemoveImage: vi.fn(),
+      hasModels: true,
+      suggestedText: '',
+      onClearSuggestion: vi.fn(),
+      onOpenSettings: vi.fn(),
+    };
+
+    return {
+      ...render(<InputArea {...defaults} {...props} />),
+      props: { ...defaults, ...props },
+    };
+  }
+
+  it('submits on Enter and clears the input', () => {
+    const { props } = renderInputArea();
+    const textbox = screen.getByLabelText('Task description');
+
+    fireEvent.input(textbox, { target: { value: 'Open settings page' } });
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    expect(props.onSend).toHaveBeenCalledWith('Open settings page');
+    expect(textbox.value).toBe('');
+  });
+
+  it('opens settings instead of sending when no model is configured', () => {
+    const { props } = renderInputArea({ hasModels: false });
+    const textbox = screen.getByLabelText('Task description');
+
+    fireEvent.input(textbox, { target: { value: 'Run task' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(props.onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(props.onSend).not.toHaveBeenCalled();
+  });
+
+  it('applies suggested text and acknowledges it once', () => {
+    const { props } = renderInputArea({ suggestedText: 'Use this prompt' });
+
+    expect(screen.getByDisplayValue('Use this prompt')).not.toBeNull();
+    expect(props.onClearSuggestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows stop button while running', () => {
+    const { props } = renderInputArea({ isRunning: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+    expect(props.onStop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/sidepanel-preact/components/Message.test.jsx
+++ b/src/sidepanel-preact/components/Message.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/preact';
+import { Message } from './Message';
+
+describe('Message', () => {
+  it('renders assistant markdown and escapes unsafe html', () => {
+    const { container } = render(
+      <Message message={{ type: 'assistant', text: '**Bold** <script>alert(1)</script>' }} />
+    );
+
+    expect(container.querySelector('.message.assistant')).not.toBeNull();
+    expect(container.querySelector('strong')?.textContent).toBe('Bold');
+    expect(container.innerHTML).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('renders user attachments and text', () => {
+    render(
+      <Message
+        message={{
+          type: 'user',
+          text: 'Check this screenshot',
+          images: ['data:image/png;base64,abc'],
+        }}
+      />
+    );
+
+    expect(screen.getByText('Check this screenshot')).not.toBeNull();
+    expect(screen.getByAltText('Attached 1')).not.toBeNull();
+  });
+
+  it('renders thinking and error states', () => {
+    const { rerender } = render(<Message message={{ type: 'thinking' }} />);
+    expect(screen.getByText('Thinking...')).not.toBeNull();
+
+    rerender(<Message message={{ type: 'error', text: 'Error: failed' }} />);
+    expect(screen.getByText('Error: failed')).not.toBeNull();
+  });
+});

--- a/src/sidepanel-preact/components/StepsSection.test.jsx
+++ b/src/sidepanel-preact/components/StepsSection.test.jsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/preact';
+import { StepsSection } from './StepsSection';
+
+describe('StepsSection', () => {
+  it('renders completed and pending steps, auto-expanded for in-flight work', () => {
+    const { container } = render(
+      <StepsSection
+        steps={[
+          {
+            tool: 'find',
+            input: { query: 'pricing' },
+            result: { output: 'Found pricing table' },
+          },
+        ]}
+        pendingStep={{
+          tool: 'navigate',
+          input: { url: 'https://example.com/dashboard' },
+        }}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /1 steps completed, 1 in progress/i })).not.toBeNull();
+    expect(container.querySelector('.steps-list.visible')).not.toBeNull();
+    expect(screen.getByText('Finding "pricing"')).not.toBeNull();
+    expect(screen.getByText('Found pricing table')).not.toBeNull();
+  });
+
+  it('collapses and expands when toggled', () => {
+    const { container } = render(
+      <StepsSection
+        steps={[{ tool: 'tabs_create', input: {}, result: { output: 'Created new tab' } }]}
+        pendingStep={null}
+      />
+    );
+
+    const toggle = screen.getByRole('button', { name: /1 steps completed/i });
+    expect(container.querySelector('.steps-list.visible')).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(container.querySelector('.steps-list.visible')).not.toBeNull();
+    expect(screen.getByText('Creating new tab')).not.toBeNull();
+  });
+});

--- a/src/sidepanel-preact/hooks/useChat.test.jsx
+++ b/src/sidepanel-preact/hooks/useChat.test.jsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from '@testing-library/preact';
+import { act } from 'preact/test-utils';
+import { useChat } from './useChat';
+
+function ChatHarness({ onReady }) {
+  const chat = useChat();
+  onReady(chat);
+
+  return (
+    <div>
+      <div data-testid="messages">{JSON.stringify(chat.messages)}</div>
+      <div data-testid="pending-step">{JSON.stringify(chat.pendingStep)}</div>
+      <div data-testid="pending-plan">{JSON.stringify(chat.pendingPlan)}</div>
+      <div data-testid="running">{String(chat.isRunning)}</div>
+    </div>
+  );
+}
+
+describe('useChat', () => {
+  it('sends a task through chrome runtime and records the user message', async () => {
+    let api;
+    render(<ChatHarness onReady={(value) => { api = value; }} />);
+
+    await act(async () => {
+      await api.sendMessage('Open the billing tab');
+    });
+
+    expect(chrome.tabs.query).toHaveBeenCalledWith({ active: true, currentWindow: true });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'START_TASK',
+      payload: {
+        tabId: 123,
+        task: 'Open the billing tab',
+        askBeforeActing: false,
+        images: [],
+        tabGroupId: null,
+      },
+    });
+
+    const messages = JSON.parse(screen.getByTestId('messages').textContent);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].type).toBe('user');
+    expect(messages[0].text).toBe('Open the billing tab');
+    expect(screen.getByTestId('running').textContent).toBe('true');
+  });
+
+  it('turns runtime updates into assistant messages with step history', async () => {
+    let api;
+    render(<ChatHarness onReady={(value) => { api = value; }} />);
+
+    act(() => {
+      globalThis.__emitRuntimeMessage({ type: 'TASK_UPDATE', update: { status: 'thinking' } });
+    });
+    await waitFor(() => {
+      const messages = JSON.parse(screen.getByTestId('messages').textContent);
+      expect(messages.at(-1)?.type).toBe('thinking');
+    });
+
+    act(() => {
+      globalThis.__emitRuntimeMessage({
+        type: 'TASK_UPDATE',
+        update: { status: 'streaming', text: 'Inspecting the page' },
+      });
+    });
+    await waitFor(() => {
+      const messages = JSON.parse(screen.getByTestId('messages').textContent);
+      expect(messages.at(-1)?.type).toBe('streaming');
+      expect(messages.at(-1)?.text).toBe('Inspecting the page');
+    });
+
+    act(() => {
+      globalThis.__emitRuntimeMessage({
+        type: 'TASK_UPDATE',
+        update: { status: 'executing', tool: 'find', input: { query: 'upgrade button' } },
+      });
+      globalThis.__emitRuntimeMessage({
+        type: 'TASK_UPDATE',
+        update: { status: 'executed', tool: 'find', result: { output: 'Found it' } },
+      });
+      globalThis.__emitRuntimeMessage({
+        type: 'TASK_UPDATE',
+        update: { status: 'message', text: 'Upgrade button is visible.' },
+      });
+    });
+
+    await waitFor(() => {
+      const messages = JSON.parse(screen.getByTestId('messages').textContent);
+      const assistant = messages.at(-1);
+      expect(assistant.type).toBe('assistant');
+      expect(assistant.text).toBe('Upgrade button is visible.');
+      expect(assistant.steps).toHaveLength(1);
+      expect(assistant.steps[0].tool).toBe('find');
+      expect(JSON.parse(screen.getByTestId('pending-step').textContent)).toBeNull();
+    });
+
+    expect(api.messages.at(-1).steps[0].result.output).toBe('Found it');
+  });
+
+  it('handles plan approval, task errors, and chat clearing', async () => {
+    let api;
+    render(<ChatHarness onReady={(value) => { api = value; }} />);
+
+    act(() => {
+      globalThis.__emitRuntimeMessage({ type: 'PLAN_APPROVAL_REQUIRED', plan: { steps: ['Step 1'] } });
+    });
+    expect(JSON.parse(screen.getByTestId('pending-plan').textContent)).toEqual({ steps: ['Step 1'] });
+
+    await act(async () => {
+      api.addImage('data:image/png;base64,abc');
+      await api.approvePlan();
+    });
+    expect(chrome.runtime.sendMessage).toHaveBeenLastCalledWith({
+      type: 'PLAN_APPROVAL_RESPONSE',
+      payload: { approved: true },
+    });
+
+    act(() => {
+      globalThis.__emitRuntimeMessage({ type: 'TASK_ERROR', error: 'Something broke' });
+    });
+    await waitFor(() => {
+      const messages = JSON.parse(screen.getByTestId('messages').textContent);
+      expect(messages.at(-1).type).toBe('error');
+      expect(messages.at(-1).text).toBe('Error: Something broke');
+    });
+
+    await act(async () => {
+      api.clearChat();
+    });
+
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'CLEAR_CONVERSATION' });
+    expect(JSON.parse(screen.getByTestId('messages').textContent)).toEqual([]);
+    expect(screen.getByTestId('running').textContent).toBe('false');
+  });
+
+  it('adds an error message instead of starting when there is no active tab', async () => {
+    chrome.tabs.query.mockResolvedValueOnce([]);
+
+    let api;
+    render(<ChatHarness onReady={(value) => { api = value; }} />);
+
+    await act(async () => {
+      await api.sendMessage('Try with no active tab');
+    });
+
+    const messages = JSON.parse(screen.getByTestId('messages').textContent);
+    expect(messages.at(-1).type).toBe('error');
+    expect(messages.at(-1).text).toBe('No active tab found');
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'START_TASK' }));
+  });
+});

--- a/src/sidepanel-preact/hooks/useConfig.test.jsx
+++ b/src/sidepanel-preact/hooks/useConfig.test.jsx
@@ -1,0 +1,283 @@
+import { render, screen, waitFor } from '@testing-library/preact';
+import { act } from 'preact/test-utils';
+import { useConfig } from './useConfig';
+
+function ConfigHarness({ onReady }) {
+  const config = useConfig();
+  onReady(config);
+
+  return (
+    <div>
+      <div data-testid="loading">{String(config.isLoading)}</div>
+      <div data-testid="available-models">{JSON.stringify(config.availableModels)}</div>
+      <div data-testid="current-model">{JSON.stringify(config.currentModel)}</div>
+      <div data-testid="agent-default-index">{String(config.currentAgentDefaultIndex)}</div>
+      <div data-testid="onboarding">{JSON.stringify(config.onboarding)}</div>
+      <div data-testid="oauth-status">{JSON.stringify(config.oauthStatus)}</div>
+      <div data-testid="codex-status">{JSON.stringify(config.codexStatus)}</div>
+      <div data-testid="user-skills">{JSON.stringify(config.userSkills)}</div>
+    </div>
+  );
+}
+
+function mockConfigMessages({
+  config = {},
+  onboarding = {},
+  oauth = { isOAuthEnabled: false, isAuthenticated: false },
+  codex = { isAuthenticated: false },
+  extra = {},
+} = {}) {
+  chrome.storage.local.get.mockResolvedValue(onboarding);
+  chrome.runtime.sendMessage.mockImplementation(async (message) => {
+    if (extra[message.type]) return extra[message.type](message);
+
+    switch (message.type) {
+      case 'GET_CONFIG':
+        return {
+          providerKeys: {},
+          customModels: [],
+          currentModelIndex: 0,
+          agentDefaultConfig: null,
+          userSkills: [],
+          builtInSkills: [],
+          ...config,
+        };
+      case 'GET_OAUTH_STATUS':
+        return oauth;
+      case 'GET_CODEX_STATUS':
+        return codex;
+      default:
+        return { success: true };
+    }
+  });
+}
+
+describe('useConfig', () => {
+  it('loads config and builds available models from API keys, OAuth, Codex, and custom models', async () => {
+    mockConfigMessages({
+      config: {
+        providerKeys: {
+          anthropic: 'anthropic-key',
+          openai: 'openai-key',
+          vertex: JSON.stringify({ project_id: 'hanzi-project' }),
+        },
+        customModels: [
+          {
+            name: 'Local Custom',
+            modelId: 'local-model',
+            baseUrl: 'http://localhost:4000/v1/chat/completions',
+            apiKey: 'local-key',
+          },
+        ],
+        currentModelIndex: 1,
+        agentDefaultConfig: {
+          provider: 'anthropic',
+          model: 'claude-opus-4-20250514',
+          apiBaseUrl: 'https://api.anthropic.com/v1/messages',
+          authMethod: 'api_key',
+        },
+        userSkills: [{ domain: 'example.com', skill: 'custom skill' }],
+        builtInSkills: [{ domain: 'x.com', skill: 'builtin' }],
+      },
+      onboarding: {
+        onboarding_completed: false,
+        onboarding_primary_mode: 'byom',
+      },
+      oauth: { isOAuthEnabled: true, isAuthenticated: true },
+      codex: { isAuthenticated: true },
+    });
+
+    let api;
+    render(<ConfigHarness onReady={(value) => { api = value; }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    const availableModels = JSON.parse(screen.getByTestId('available-models').textContent);
+    expect(availableModels.some((model) => model.provider === 'codex' && model.authMethod === 'codex_oauth')).toBe(true);
+    expect(availableModels.some((model) => model.provider === 'anthropic' && model.authMethod === 'oauth')).toBe(true);
+    expect(availableModels.some((model) => model.provider === 'anthropic' && model.authMethod === 'api_key')).toBe(true);
+    expect(availableModels.some((model) => model.provider === 'openai' && model.modelId === 'gpt-5')).toBe(true);
+    expect(availableModels.some((model) => model.provider === 'google' && model.baseUrl.includes('/projects/hanzi-project/locations/us-central1'))).toBe(true);
+    expect(availableModels.some((model) => model.name === 'Local Custom')).toBe(true);
+
+    expect(JSON.parse(screen.getByTestId('current-model').textContent)).toEqual(availableModels[1]);
+    expect(screen.getByTestId('agent-default-index').textContent).not.toBe('-1');
+    expect(JSON.parse(screen.getByTestId('onboarding').textContent)).toEqual({
+      completed: false,
+      primaryMode: 'byom',
+    });
+    expect(JSON.parse(screen.getByTestId('oauth-status').textContent)).toEqual({
+      isOAuthEnabled: true,
+      isAuthenticated: true,
+    });
+    expect(JSON.parse(screen.getByTestId('codex-status').textContent)).toEqual({
+      isAuthenticated: true,
+    });
+    expect(JSON.parse(screen.getByTestId('user-skills').textContent)).toEqual([
+      { domain: 'example.com', skill: 'custom skill' },
+    ]);
+
+    expect(api.currentModelIndex).toBe(1);
+  });
+
+  it('selects a model, clears chat, and persists the selected model payload', async () => {
+    mockConfigMessages({
+      config: {
+        providerKeys: { openai: 'openai-key' },
+      },
+    });
+
+    let api;
+    render(<ConfigHarness onReady={(value) => { api = value; }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    const sendCountBefore = chrome.runtime.sendMessage.mock.calls.length;
+
+    await act(async () => {
+      await api.selectModel(1);
+    });
+
+    const calls = chrome.runtime.sendMessage.mock.calls.slice(sendCountBefore).map(([message]) => message);
+    expect(calls[0]).toEqual({ type: 'CLEAR_CHAT' });
+    expect(calls[1].type).toBe('SAVE_CONFIG');
+    expect(calls[1].payload).toMatchObject({
+      currentModelIndex: 1,
+      provider: 'openai',
+      authMethod: 'api_key',
+    });
+    expect(calls[1].payload.model).toBeTruthy();
+    expect(calls[1].payload.apiBaseUrl).toContain('openai.com');
+  });
+
+  it('saves agent default selection with serialized model config', async () => {
+    mockConfigMessages({
+      config: {
+        providerKeys: { openai: 'openai-key' },
+      },
+    });
+
+    let api;
+    render(<ConfigHarness onReady={(value) => { api = value; }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    const sendCountBefore = chrome.runtime.sendMessage.mock.calls.length;
+
+    await act(async () => {
+      await api.selectAgentDefault(0);
+    });
+
+    const calls = chrome.runtime.sendMessage.mock.calls.slice(sendCountBefore).map(([message]) => message);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      type: 'SAVE_CONFIG',
+      payload: {
+        agentDefaultConfig: expect.objectContaining({
+          name: expect.any(String),
+          provider: 'openai',
+          model: expect.any(String),
+          apiBaseUrl: expect.stringContaining('openai.com'),
+          apiKey: 'openai-key',
+          authMethod: 'api_key',
+        }),
+      },
+    });
+  });
+
+  it('updates local config state and saves mutable settings', async () => {
+    mockConfigMessages();
+
+    let api;
+    render(<ConfigHarness onReady={(value) => { api = value; }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    act(() => {
+      api.setProviderKey('openrouter', 'router-key');
+      api.addCustomModel({
+        name: 'Edge Model',
+        modelId: 'edge',
+        baseUrl: 'https://edge.local/v1/chat/completions',
+        apiKey: 'edge-key',
+      });
+      api.addUserSkill({ domain: 'docs.example.com', skill: 'Read docs first' });
+      api.addUserSkill({ domain: 'docs.example.com', skill: 'Updated skill' });
+    });
+
+    await act(async () => {
+      await api.saveConfig();
+    });
+
+    const lastCall = chrome.runtime.sendMessage.mock.calls.at(-1)[0];
+    expect(lastCall).toEqual({
+      type: 'SAVE_CONFIG',
+      payload: {
+        providerKeys: { openrouter: 'router-key' },
+        customModels: [
+          {
+            name: 'Edge Model',
+            modelId: 'edge',
+            baseUrl: 'https://edge.local/v1/chat/completions',
+            apiKey: 'edge-key',
+          },
+        ],
+        currentModelIndex: 0,
+        userSkills: [{ domain: 'docs.example.com', skill: 'Updated skill' }],
+      },
+    });
+  });
+
+  it('reloads config after CLI and Codex credential import/logout flows', async () => {
+    let configFetches = 0;
+    mockConfigMessages({
+      extra: {
+        IMPORT_CLI_CREDENTIALS: () => ({ success: true, credentials: { source: 'cli' } }),
+        OAUTH_LOGOUT: () => ({ success: true }),
+        IMPORT_CODEX_CREDENTIALS: () => ({ success: true, credentials: { source: 'codex' } }),
+        CODEX_LOGOUT: () => ({ success: true }),
+        GET_CONFIG: () => {
+          configFetches += 1;
+          return {
+            providerKeys: {},
+            customModels: [],
+            currentModelIndex: 0,
+            agentDefaultConfig: null,
+            userSkills: [],
+            builtInSkills: [],
+          };
+        },
+      },
+    });
+
+    let api;
+    render(<ConfigHarness onReady={(value) => { api = value; }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    const baselineFetches = configFetches;
+
+    await act(async () => {
+      await api.importCLI();
+      await api.logoutCLI();
+      await api.importCodex();
+      await api.logoutCodex();
+    });
+
+    expect(configFetches).toBeGreaterThan(baselineFetches);
+    expect(chrome.runtime.sendMessage.mock.calls.some(([message]) => message.type === 'IMPORT_CLI_CREDENTIALS')).toBe(true);
+    expect(chrome.runtime.sendMessage.mock.calls.some(([message]) => message.type === 'OAUTH_LOGOUT')).toBe(true);
+    expect(chrome.runtime.sendMessage.mock.calls.some(([message]) => message.type === 'IMPORT_CODEX_CREDENTIALS')).toBe(true);
+    expect(chrome.runtime.sendMessage.mock.calls.some(([message]) => message.type === 'CODEX_LOGOUT')).toBe(true);
+  });
+});

--- a/src/sidepanel-preact/utils/format.test.js
+++ b/src/sidepanel-preact/utils/format.test.js
@@ -1,0 +1,34 @@
+import {
+  escapeHtml,
+  formatMarkdown,
+  formatStepResult,
+  getActionDescription,
+} from './format';
+
+describe('format utils', () => {
+  it('formats markdown blocks while escaping unsafe html', () => {
+    const html = formatMarkdown('Hello\n- **World**\n1. `code`\n<script>alert(1)</script>');
+
+    expect(html).toContain('<p>Hello</p>');
+    expect(html).toContain('<ul><li><strong>World</strong></li></ul>');
+    expect(html).toContain('<ol><li><code>code</code></li></ol>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('describes tool actions for common extension steps', () => {
+    expect(getActionDescription('computer', { action: 'left_click', ref: 'Submit button' })).toBe('Clicking Submit button');
+    expect(getActionDescription('navigate', { url: 'https://example.com/path' })).toBe('Navigating to https://example.com/path...');
+    expect(getActionDescription('find', { query: 'billing' })).toBe('Finding "billing"');
+  });
+
+  it('formats step results conservatively', () => {
+    expect(formatStepResult({ error: 'Timed out' })).toBe('Error: Timed out');
+    expect(formatStepResult({ output: 'done' })).toBe('done');
+    expect(formatStepResult('x'.repeat(120))).toBe(`${'x'.repeat(100)}...`);
+  });
+
+  it('escapes html fragments directly', () => {
+    expect(escapeHtml('<img src=x onerror=1>')).toBe('&lt;img src=x onerror=1&gt;');
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/preact';
+
+const runtimeListeners = new Set();
+
+function createChromeMock() {
+  return {
+    runtime: {
+      getURL: vi.fn((path) => `chrome-extension://test/${path}`),
+      sendMessage: vi.fn(async () => ({})),
+      onMessage: {
+        addListener: vi.fn((listener) => runtimeListeners.add(listener)),
+        removeListener: vi.fn((listener) => runtimeListeners.delete(listener)),
+      },
+    },
+    tabs: {
+      query: vi.fn(async () => [{ id: 123 }]),
+    },
+    storage: {
+      local: {
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => {}),
+        remove: vi.fn(async () => {}),
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  runtimeListeners.clear();
+  globalThis.chrome = createChromeMock();
+  globalThis.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => [],
+    text: async () => '[]',
+  }));
+  globalThis.requestAnimationFrame = vi.fn((callback) => {
+    callback();
+    return 1;
+  });
+  globalThis.cancelAnimationFrame = vi.fn();
+  globalThis.__emitRuntimeMessage = (message) => {
+    for (const listener of runtimeListeners) listener(message);
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  delete globalThis.__emitRuntimeMessage;
+  vi.restoreAllMocks();
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import preact from '@preact/preset-vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [preact()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./test/setup.js'],
+    include: [
+      'src/background/**/*.test.{js,jsx}',
+      'src/sidepanel-preact/**/*.test.{js,jsx}',
+    ],
+    exclude: ['src/tests/**'],
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src/sidepanel-preact'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Add a runnable Vitest-based test baseline for the Chrome extension and extend unit coverage across sidepanel UI, hooks, and background configuration logic.

## What changed

- add root-level Vitest test runner for extension code
- add shared Chrome/jsdom test setup
- extend test setup with additional mocks (`chrome.runtime.getURL`, `fetch`)
- add tests for:
  - sidepanel formatting helpers
  - retry utilities
  - `Message`
  - `StepsSection`
  - `InputArea`
  - `useChat`
  - `useConfig`
  - background `api.js` config/provider helpers
- add root test scripts in `package.json`
- scope Vitest to the new extension-focused tests and exclude legacy `src/tests/**`

## Validation

Ran successfully:

```bash
npm test
npm run build
```

Current result at submission time:

- 8 test files passed
- 30 tests passed

Manual smoke test:

- extension loads in Chrome
- sidepanel opens successfully

## Scope / Non-goals

This PR establishes and expands extension unit-test coverage, but does not yet cover:

- most background/modules/*
- content/*
- real Chrome integration behavior
- end-to-end extension flows