### PR TITLE
security: replace innerHTML in pairing templates with safe DOM updates

### DIFF
--- a/server/src/managed/templates/pair-self.html
+++ b/server/src/managed/templates/pair-self.html
@@ -34,6 +34,45 @@
     const statusEl = document.getElementById("status");
     let paired = false;
 
+    function clearStatus() {
+      while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
+    }
+
+    function setStatusClass(name) {
+      statusEl.className = `status ${name}`;
+    }
+
+    function setStatusText(name, text) {
+      setStatusClass(name);
+      clearStatus();
+      statusEl.textContent = text;
+    }
+
+    function setStatusLoading(text) {
+      setStatusClass("status-connecting");
+      clearStatus();
+      const spinner = document.createElement("span");
+      spinner.className = "spinner";
+      spinner.setAttribute("aria-hidden", "true");
+      statusEl.appendChild(spinner);
+      statusEl.appendChild(document.createTextNode(text));
+    }
+
+    function setInstallStatus() {
+      setStatusClass("status-error");
+      clearStatus();
+      statusEl.appendChild(document.createTextNode("Hanzi extension not detected. "));
+      const link = document.createElement("a");
+      link.href = "https://chromewebstore.google.com/detail/hanzi-browse/iklpkemlmbhemkiojndpbhoakgikpmcd";
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.style.color = "#ad5a34";
+      link.style.fontWeight = "600";
+      link.textContent = "Install it";
+      statusEl.appendChild(link);
+      statusEl.appendChild(document.createTextNode(", then reload this page."));
+    }
+
     window.addEventListener("message", (e) => {
       if (e.data?.type === "HANZI_EXTENSION_READY" && !paired) {
         pair();
@@ -41,25 +80,22 @@
       if (e.data?.type === "HANZI_PAIR_RESULT") {
         paired = true;
         if (e.data.success) {
-          statusEl.className = "status status-success";
-          statusEl.innerHTML = "✓ Connected! You can close this tab and use the sidepanel.";
+          setStatusText("status-success", "✓ Connected! You can close this tab and use the sidepanel.");
         } else {
-          statusEl.className = "status status-error";
-          statusEl.innerHTML = "Failed: " + (e.data.error || "unknown error");
+          setStatusText("status-error", "Failed: " + (e.data.error || "unknown error"));
         }
       }
     });
 
     function pair() {
-      statusEl.innerHTML = '<span class="spinner"></span> Pairing...';
+      setStatusLoading(" Pairing...");
       window.postMessage({ type: "HANZI_PAIR", token: TOKEN, apiUrl: API_URL }, "*");
     }
 
     window.postMessage({ type: "HANZI_PING" }, "*");
     setTimeout(() => {
       if (!paired) {
-        statusEl.className = "status status-error";
-        statusEl.innerHTML = 'Hanzi extension not detected. <a href="https://chromewebstore.google.com/detail/hanzi-browse/iklpkemlmbhemkiojndpbhoakgikpmcd" target="_blank" style="color:#ad5a34;font-weight:600">Install it</a>, then reload this page.';
+        setInstallStatus();
       }
     }, 3000);
   </script>

--- a/server/src/managed/templates/pair.html
+++ b/server/src/managed/templates/pair.html
@@ -38,6 +38,43 @@
     const EXTENSION_URL = "{{EXTENSION_URL}}";
     const statusEl = document.getElementById("status");
 
+    function clearStatus() {
+      while (statusEl.firstChild) statusEl.removeChild(statusEl.firstChild);
+    }
+
+    function setStatusClass(name) {
+      statusEl.className = `status ${name}`;
+    }
+
+    function setStatusText(name, text) {
+      setStatusClass(name);
+      clearStatus();
+      statusEl.textContent = text;
+    }
+
+    function setStatusLoading(text) {
+      setStatusClass("status-connecting");
+      clearStatus();
+      const spinner = document.createElement("span");
+      spinner.className = "spinner";
+      spinner.setAttribute("aria-hidden", "true");
+      statusEl.appendChild(spinner);
+      statusEl.appendChild(document.createTextNode(text));
+    }
+
+    function setStatusInstall(message, href, linkText, suffix) {
+      setStatusClass("status-install");
+      clearStatus();
+      statusEl.appendChild(document.createTextNode(message + " "));
+      const link = document.createElement("a");
+      link.href = href;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = linkText;
+      statusEl.appendChild(link);
+      statusEl.appendChild(document.createTextNode(suffix));
+    }
+
     // Step 1: Detect extension
     let extensionDetected = false;
 
@@ -47,8 +84,7 @@
         doPair();
       }
       if (e.data?.type === "HANZI_SESSION_SET") {
-        statusEl.className = "status status-success";
-        statusEl.innerHTML = "✓ Browser connected! You can close this tab.";
+        setStatusText("status-success", "✓ Browser connected! You can close this tab.");
       }
     });
 
@@ -56,15 +92,18 @@
 
     setTimeout(() => {
       if (!extensionDetected) {
-        statusEl.className = "status status-install";
-        statusEl.innerHTML = 'Hanzi extension not found. <a href="' + EXTENSION_URL + '" target="_blank">Install it here</a>, then reload this page.';
+        setStatusInstall(
+          "Hanzi extension not found.",
+          EXTENSION_URL,
+          "Install it here",
+          ", then reload this page."
+        );
       }
     }, 2000);
 
     // Step 2: Page calls register API directly (same-origin, no content script relay)
     async function doPair() {
-      statusEl.className = "status status-connecting";
-      statusEl.innerHTML = '<span class="spinner"></span> Connecting...';
+      setStatusLoading(" Connecting...");
       try {
         const res = await fetch(API_URL + "/v1/browser-sessions/register", {
           method: "POST",
@@ -73,8 +112,7 @@
         });
         const data = await res.json();
         if (!data.session_token) {
-          statusEl.className = "status status-error";
-          statusEl.innerHTML = "Pairing failed: " + (data.error || "unknown error");
+          setStatusText("status-error", "Pairing failed: " + (data.error || "unknown error"));
           return;
         }
         // Step 3: Tell extension to set the session (no API call needed from extension)
@@ -88,8 +126,7 @@
           relayUrl: relayUrl,
         }, "*");
       } catch (err) {
-        statusEl.className = "status status-error";
-        statusEl.innerHTML = "Pairing failed: " + err.message;
+        setStatusText("status-error", "Pairing failed: " + err.message);
       }
     }
   </script>


### PR DESCRIPTION
## Summary

Replace `innerHTML`-based status updates in managed pairing templates with safe DOM updates.

## What changed

- remove `innerHTML` writes from:
  - `server/src/managed/templates/pair.html`
  - `server/src/managed/templates/pair-self.html`
- render dynamic status text with `textContent`
- create spinner and install-link nodes via DOM APIs
- add `rel="noopener noreferrer"` to external links opened with `_blank`

## Why

These templates were using `innerHTML` for dynamic status updates. While the current inputs are limited, replacing them with DOM-based updates reduces HTML injection risk and makes the rendering path safer by default.

## Validation

- confirmed rendering templates no longer contain `innerHTML`
- verified external `_blank` links now include `rel="noopener noreferrer"`
- reviewed behavior parity for:
  - connecting state
  - success state
  - error state
  - install-extension fallback link