### PR TITLE
fixes YAML parsing error in the data-extractor/SKILL.md

### DIFF
--- a/server/skills/data-extractor/SKILL.md
+++ b/server/skills/data-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-extractor
-description: Extract structured data from websites into CSV or JSON. Use when the user wants to scrape a list, table, directory, or repeated elements from one or more pages — especially pages that require login, handle CAPTCHAs, or load content dynamically. Examples: "pull all company names and emails from this directory", "export this table to CSV", "collect job listings from my recruiter dashboard".
+description: 'Extract structured data from websites into CSV or JSON. Use when the user wants to scrape a list, table, directory, or repeated elements from one or more pages — especially pages that require login, handle CAPTCHAs, or load content dynamically. Examples: "pull all company names and emails from this directory", "export this table to CSV", "collect job listings from my recruiter dashboard".'
 category: productivity
 ---
 


### PR DESCRIPTION
Wraps the `description` value in single quotes so the frontmatter parses correctly.
<img width="934" height="261" alt="Screenshot 2026-04-26 at 8 04 39 AM" src="https://github.com/user-attachments/assets/ed4a8a1c-56a2-45d7-b41b-42ded0ef1316" />
