### PR TITLE
feat: add analytics-verifier skill

### DIFF
--- a/server/skills/analytics-verifier/SKILL.md
+++ b/server/skills/analytics-verifier/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: analytics-verifier
+description: Verifies that GA4 and GTM analytics tracking is correctly implemented on a website by navigating real pages, firing events, and inspecting the dataLayer. Use this skill when asked to audit, verify, or check analytics tracking on a site.
+category: productivity
+---
+
+# Analytics Verifier
+
+You are an analytics QA specialist. You use a real browser to verify that GA4 and GTM tracking is correctly implemented — checking that tracking scripts load, events fire, and dataLayer data is accurate. You do not modify any tracking code; you only observe and report.
+
+## Tool Selection Rule
+
+Always use the browser (hanzi-browse) for this skill. Analytics verification requires executing JavaScript in a live page context — static analysis is not sufficient.
+
+## Before Starting
+
+Call `browser_status` to confirm the extension is available.
+If unavailable, tell the user to install it from: https://github.com/hanzili/hanzi-browse
+
+## What You Need
+
+Ask the user for:
+- **Target URL(s)** — one or more pages to verify (e.g. homepage, product page, checkout)
+- **Expected events** (optional) — any specific events they want confirmed (e.g. `purchase`, `sign_up`)
+- **GA Measurement ID** (optional) — e.g. `G-XXXXXXXXXX`, to confirm the correct property is firing
+
+---
+
+## Phase 1 — Page Load & Script Detection (Browser)
+
+Navigate to the target URL and check for analytics script presence.
+
+```javascript
+// Check for GTM container
+const gtmPresent = typeof window.google_tag_manager !== 'undefined';
+const gtmContainers = gtmPresent ? Object.keys(window.google_tag_manager) : [];
+
+// Check for GA4 / gtag
+const gtagPresent = typeof window.gtag === 'function';
+
+// Check for legacy Universal Analytics
+const uaPresent = typeof window.ga === 'function';
+
+// Check dataLayer exists and has entries
+const dataLayer = window.dataLayer || [];
+
+console.log(JSON.stringify({
+  gtmPresent,
+  gtmContainers,
+  gtagPresent,
+  uaPresent,
+  dataLayerLength: dataLayer.length,
+  dataLayerFirstEntry: dataLayer[0] || null
+}));
+```
+
+📸 Screenshot: full page after load.
+
+---
+
+## Phase 2 — dataLayer Inspection (Browser)
+
+Inspect the full dataLayer to identify what events have already fired on load.
+
+```javascript
+const dataLayer = window.dataLayer || [];
+const events = dataLayer.map((entry, i) => ({
+  index: i,
+  event: entry.event || '(no event key)',
+  keys: Object.keys(entry)
+}));
+console.log(JSON.stringify(events, null, 2));
+```
+
+Look for:
+- `gtm.js` — GTM loaded successfully
+- `gtm.dom` — DOM ready event
+- `gtm.load` — Page fully loaded
+- `page_view` — GA4 page view fired
+
+---
+
+## Phase 3 — Interaction Events (Browser)
+
+Simulate key user interactions and verify events fire correctly.
+
+**3a. Click a primary CTA button:**
+```javascript
+// Find and click the most prominent CTA
+const cta = document.querySelector('a[href*="signup"], a[href*="register"], button[type="submit"], .cta, .btn-primary');
+if (cta) {
+  const before = (window.dataLayer || []).length;
+  cta.click();
+  await new Promise(r => setTimeout(r, 1000));
+  const after = (window.dataLayer || []).length;
+  const newEvents = (window.dataLayer || []).slice(before);
+  console.log(JSON.stringify({ clicked: cta.innerText?.trim(), newEvents }));
+} else {
+  console.log('No CTA found');
+}
+```
+
+**3b. Check for scroll tracking:**
+```javascript
+window.scrollTo(0, document.body.scrollHeight / 2);
+await new Promise(r => setTimeout(r, 1000));
+const scrollEvents = (window.dataLayer || []).filter(e => e.event && e.event.includes('scroll'));
+console.log(JSON.stringify(scrollEvents));
+```
+
+📸 Screenshot after interactions.
+
+---
+
+## Phase 4 — GA4 Configuration Check (Browser)
+
+Verify the correct GA4 Measurement ID is configured.
+
+```javascript
+const gtm = window.google_tag_manager || {};
+const containers = Object.keys(gtm);
+
+// Try to find GA4 config from gtag calls
+const ga4Tags = [];
+if (window.dataLayer) {
+  window.dataLayer.forEach(entry => {
+    if (entry[0] === 'config' && typeof entry[1] === 'string' && entry[1].startsWith('G-')) {
+      ga4Tags.push(entry[1]);
+    }
+  });
+}
+
+console.log(JSON.stringify({ gtmContainers: containers, ga4MeasurementIds: ga4Tags }));
+```
+
+---
+
+## Phase 5 — Multi-Page Verification (Browser)
+
+Repeat Phases 1–3 on at least 2 additional pages (e.g. an inner page, a pricing or contact page) to confirm tracking is consistent site-wide, not just on the homepage.
+
+Navigate to each page and re-run the Phase 1 dataLayer check. Confirm:
+- `page_view` fires on each navigation
+- GTM container persists across pages
+- No console errors related to analytics scripts
+
+---
+
+## Report Format
+
+After completing all phases, output a structured audit report:
+
+```
+📊 Analytics Tracking Audit Report
+====================================
+Site: [URL]
+Date: [date]
+
+TRACKING INFRASTRUCTURE
+  GTM Present:        ✓ / ✗  [container ID if found]
+  GA4 (gtag) Present: ✓ / ✗  [measurement ID if found]
+  Legacy UA Present:  ✓ / ✗  (should be ✗ — UA is deprecated)
+
+PAGE LOAD EVENTS
+  gtm.js fired:   ✓ / ✗
+  gtm.dom fired:  ✓ / ✗
+  gtm.load fired: ✓ / ✗
+  page_view fired: ✓ / ✗
+
+INTERACTION EVENTS
+  CTA click tracked:    ✓ / ✗ / ⚠ [event name if found]
+  Scroll depth tracked: ✓ / ✗ / ⚠
+
+MULTI-PAGE CONSISTENCY
+  Page 2 [URL]: ✓ / ✗
+  Page 3 [URL]: ✓ / ✗
+
+ISSUES FOUND
+  ✗ [describe any missing or misconfigured tracking]
+  ⚠ [describe any warnings or inconsistencies]
+
+SCREENSHOTS
+  📸 Homepage load: [ref]
+  📸 After CTA click: [ref]
+
+VERDICT
+  [ ] Tracking healthy — all key events firing correctly
+  [ ] Partial — some events missing (see issues above)
+  [ ] Broken — tracking not loading or major events absent
+```
+
+---
+
+## Rules
+
+- **Read-only** — never modify page code, inject scripts, or alter the dataLayer
+- Always call `browser_status` before starting
+- If the page blocks JS execution, note it in the report and skip that check
+- Do not assume an event is firing correctly just because the script tag is present — verify via dataLayer
+- If expected events are provided by the user, explicitly confirm each one as ✓ or ✗
+- Verify at minimum 3 pages per audit; 5+ is preferred for a thorough report
+- If GTM is absent but GA4 loads directly via script tag, note this as a valid (non-GTM) implementation
+- Timeout: if a page does not load within 15 seconds, skip it and note in the report


### PR DESCRIPTION
## Summary

Adds `server/skills/analytics-verifier/SKILL.md` — a browser skill that verifies GA4 and GTM analytics tracking is correctly implemented on real websites.

Closes #30

## What this skill does

The analytics-verifier skill lets an AI agent use hanzi-browse to audit analytics tracking on any website. It checks that:
- GTM and GA4 scripts are present and loading
- `dataLayer` events fire correctly on page load and user interaction
- Key events like `page_view`, `gtm.js`, `gtm.dom`, and `gtm.load` are present
- Tracking is consistent across multiple pages

The skill is **read-only** — it only observes and reports, never modifies tracking code.

## Verification — 5 real sites tested with hanzi-browse

| Site | GTM | GA4 | dataLayer Events | Notes |
|------|-----|-----|-----------------|-------|
| shopify.com | ✅ GTM-TZ26LP8 | ✗ (via GTM) | 11 — `page_view`, `gtm.load`, `component_viewability` | Healthy tracking |
| netlify.com | ✅ GTM-T7WNFLD | ✅ G-X2FMMZSS59 | 18 — `gtm.load`, `OneTrustLoaded`, `firstInteraction` | Most complete setup, includes consent management |
| notion.so | ✅ GTM-MTWKTL4 | ✗ (via GTM) | 6 — `gtm.load`, `gtm.elementVisibility` | Healthy tracking |
| vercel.com | ✗ | ✗ | 0 | Uses custom in-house analytics (expected) |
| figma.com | ✗ | ✗ | 0 | Uses Statsig for analytics (expected) |

All 5 sites navigated and screenshotted via hanzi-browse. JS inspection run via Chrome DevTools on each page.

## Skill structure

Follows the existing skill format used by `seo-checker` and `e2e-tester`:
- YAML frontmatter (name, description, category)
- Tool Selection Rule + Before Starting + What You Need
- 5 execution phases with inline JS code blocks
- Structured audit report template (✓ / ✗ / ⚠)
- Rules section (read-only, 3+ pages minimum, timeout handling)